### PR TITLE
Allow updating username

### DIFF
--- a/GameSite/Views/User/Edit.cshtml
+++ b/GameSite/Views/User/Edit.cshtml
@@ -8,5 +8,10 @@
         <label asp-for="AvatarPath" class="form-label"></label>
         <input asp-for="AvatarPath" class="form-control" />
     </div>
+    <div class="mb-3">
+        <label asp-for="UserName" class="form-label"></label>
+        <input asp-for="UserName" class="form-control" />
+        <span asp-validation-for="UserName" class="text-danger"></span>
+    </div>
     <button type="submit" class="btn btn-primary">Save</button>
 </form>


### PR DESCRIPTION
## Summary
- add SignInManager and allow username changes in `UserController`
- update profile editing form with a new login field

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa69b26008323aa3836e2b93dbd92