### PR TITLE
Implement email sender service

### DIFF
--- a/GameSite/Models/EmailSettings.cs
+++ b/GameSite/Models/EmailSettings.cs
@@ -1,0 +1,10 @@
+namespace GameSite.Models
+{
+    public class EmailSettings
+    {
+        public string SmtpServer { get; set; } = string.Empty;
+        public int SmtpPort { get; set; }
+        public string FromEmail { get; set; } = string.Empty;
+        public string Password { get; set; } = string.Empty;
+    }
+}

--- a/GameSite/Program.cs
+++ b/GameSite/Program.cs
@@ -3,6 +3,8 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
 using Npgsql.EntityFrameworkCore.PostgreSQL;
 using GameSite.Models;
+using Microsoft.AspNetCore.Identity.UI.Services;
+using GameSite.Services;
 
 namespace GameSite
 {
@@ -21,6 +23,8 @@ namespace GameSite
             builder.Services.AddDefaultIdentity<ApplicationUser>(options => options.SignIn.RequireConfirmedAccount = true)
                 .AddRoles<IdentityRole>()
                 .AddEntityFrameworkStores<ApplicationDbContext>();
+            builder.Services.Configure<EmailSettings>(builder.Configuration.GetSection("EmailSettings"));
+            builder.Services.AddTransient<IEmailSender, EmailSender>();
             builder.Services.AddControllersWithViews();
 
             var app = builder.Build();

--- a/GameSite/Services/EmailSender.cs
+++ b/GameSite/Services/EmailSender.cs
@@ -1,0 +1,38 @@
+using System.Net;
+using System.Net.Mail;
+using System.Text;
+using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.Extensions.Options;
+using GameSite.Models;
+
+namespace GameSite.Services
+{
+    public class EmailSender : IEmailSender
+    {
+        private readonly EmailSettings _settings;
+
+        public EmailSender(IOptions<EmailSettings> options)
+        {
+            _settings = options.Value;
+        }
+
+        public Task SendEmailAsync(string email, string subject, string htmlMessage)
+        {
+            var client = new SmtpClient(_settings.SmtpServer, _settings.SmtpPort)
+            {
+                EnableSsl = true,
+                Credentials = new NetworkCredential(_settings.FromEmail, _settings.Password),
+                DeliveryMethod = SmtpDeliveryMethod.Network,
+                UseDefaultCredentials = false
+            };
+
+            var mailMessage = new MailMessage(_settings.FromEmail, email, subject, htmlMessage)
+            {
+                IsBodyHtml = true,
+                BodyEncoding = Encoding.UTF8
+            };
+
+            return client.SendMailAsync(mailMessage);
+        }
+    }
+}

--- a/GameSite/appsettings.json
+++ b/GameSite/appsettings.json
@@ -9,4 +9,11 @@
     }
   },
   "AllowedHosts": "*"
+  ,
+  "EmailSettings": {
+    "SmtpServer": "smtp.mail.ru",
+    "SmtpPort": 587,
+    "FromEmail": "jl_sp_amg@mail.ru",
+    "Password": ""
+  }
 }


### PR DESCRIPTION
## Summary
- add `EmailSettings` model for SMTP configuration
- implement `EmailSender` that sends email using `SmtpClient`
- register `EmailSender` in DI container
- configure `EmailSettings` in `appsettings.json`

## Testing
- `dotnet build GameSite/GameSite.csproj -clp:ErrorsOnly` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685aa917261c8323bfb158723a67b08d