### PR TITLE
Implement Google auth and custom password validation

### DIFF
--- a/GameSite/Controllers/AccountController.cs
+++ b/GameSite/Controllers/AccountController.cs
@@ -1,16 +1,25 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Google;
 using GameSite.Models;
+using GameSite.Services;
 
 namespace GameSite.Controllers
 {
     public class AccountController : Controller
     {
         private readonly SignInManager<ApplicationUser> _signInManager;
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly IGoogleAuthService _googleAuthService;
 
-        public AccountController(SignInManager<ApplicationUser> signInManager)
+        public AccountController(SignInManager<ApplicationUser> signInManager,
+            UserManager<ApplicationUser> userManager,
+            IGoogleAuthService googleAuthService)
         {
             _signInManager = signInManager;
+            _userManager = userManager;
+            _googleAuthService = googleAuthService;
         }
 
         public IActionResult Register()
@@ -37,6 +46,43 @@ namespace GameSite.Controllers
         public IActionResult ChangePassword()
         {
             return RedirectToPage("/Account/Manage/ChangePassword", new { area = "Identity" });
+        }
+
+        public IActionResult GoogleLogin(string returnUrl = "/")
+        {
+            var redirectUrl = Url.Action(nameof(GoogleResponse), "Account", new { ReturnUrl = returnUrl });
+            var properties = _googleAuthService.ConfigureExternalAuthenticationProperties(redirectUrl!);
+            return Challenge(properties, GoogleDefaults.AuthenticationScheme);
+        }
+
+        public async Task<IActionResult> GoogleResponse(string returnUrl = "/")
+        {
+            var info = await _signInManager.GetExternalLoginInfoAsync();
+            if (info == null)
+            {
+                return RedirectToAction(nameof(Login));
+            }
+
+            var signIn = await _signInManager.ExternalLoginSignInAsync(info.LoginProvider, info.ProviderKey, isPersistent: false);
+            if (signIn.Succeeded)
+            {
+                return LocalRedirect(returnUrl);
+            }
+
+            var email = info.Principal.FindFirstValue(System.Security.Claims.ClaimTypes.Email);
+            if (email != null)
+            {
+                var user = new ApplicationUser { UserName = email, Email = email, RegistrationDate = DateTime.UtcNow };
+                var result = await _userManager.CreateAsync(user);
+                if (result.Succeeded)
+                {
+                    await _userManager.AddLoginAsync(user, info);
+                    await _signInManager.SignInAsync(user, isPersistent: false);
+                    return LocalRedirect(returnUrl);
+                }
+            }
+
+            return RedirectToAction(nameof(Login));
         }
     }
 }

--- a/GameSite/Program.cs
+++ b/GameSite/Program.cs
@@ -5,6 +5,7 @@ using Npgsql.EntityFrameworkCore.PostgreSQL;
 using GameSite.Models;
 using Microsoft.AspNetCore.Identity.UI.Services;
 using GameSite.Services;
+using Microsoft.AspNetCore.Authentication.Google;
 
 namespace GameSite
 {
@@ -20,11 +21,29 @@ namespace GameSite
                 options.UseNpgsql(connectionString));
             builder.Services.AddDatabaseDeveloperPageExceptionFilter();
 
-            builder.Services.AddDefaultIdentity<ApplicationUser>(options => options.SignIn.RequireConfirmedAccount = true)
+            builder.Services.AddDefaultIdentity<ApplicationUser>(options =>
+            {
+                options.SignIn.RequireConfirmedAccount = true;
+                options.Password.RequiredLength = 4;
+                options.Password.RequireNonAlphanumeric = false;
+                options.Password.RequireLowercase = false;
+                options.Password.RequireUppercase = false;
+                options.Password.RequireDigit = false;
+            })
                 .AddRoles<IdentityRole>()
                 .AddEntityFrameworkStores<ApplicationDbContext>();
+            builder.Services.AddTransient<IPasswordValidator<ApplicationUser>, CustomPasswordValidator>();
             builder.Services.Configure<EmailSettings>(builder.Configuration.GetSection("EmailSettings"));
             builder.Services.AddTransient<IEmailSender, EmailSender>();
+            builder.Services.AddTransient<IEmailService, EmailSender>();
+            builder.Services.AddTransient<IGoogleAuthService, GoogleAuthService>();
+            builder.Services.AddAuthentication()
+                .AddGoogle(options =>
+                {
+                    var googleAuth = builder.Configuration.GetSection("Authentication:Google");
+                    options.ClientId = googleAuth["ClientId"]!;
+                    options.ClientSecret = googleAuth["ClientSecret"]!;
+                });
             builder.Services.AddControllersWithViews();
 
             var app = builder.Build();
@@ -45,6 +64,8 @@ namespace GameSite
             app.UseStaticFiles();
 
             app.UseRouting();
+
+            app.UseAuthentication();
 
             app.UseAuthorization();
 

--- a/GameSite/Services/CustomPasswordValidator.cs
+++ b/GameSite/Services/CustomPasswordValidator.cs
@@ -1,0 +1,25 @@
+using Microsoft.AspNetCore.Identity;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using GameSite.Models;
+
+namespace GameSite.Services
+{
+    public class CustomPasswordValidator : IPasswordValidator<ApplicationUser>
+    {
+        private static readonly Regex _allowed = new Regex("^[A-Za-z0-9]{4,16}$");
+
+        public Task<IdentityResult> ValidateAsync(UserManager<ApplicationUser> manager, ApplicationUser user, string? password)
+        {
+            if (password == null || !_allowed.IsMatch(password))
+            {
+                return Task.FromResult(IdentityResult.Failed(new IdentityError
+                {
+                    Description = "Password must be 4-16 characters long and contain only letters or digits."
+                }));
+            }
+
+            return Task.FromResult(IdentityResult.Success);
+        }
+    }
+}

--- a/GameSite/Services/EmailSender.cs
+++ b/GameSite/Services/EmailSender.cs
@@ -7,7 +7,7 @@ using GameSite.Models;
 
 namespace GameSite.Services
 {
-    public class EmailSender : IEmailSender
+    public class EmailSender : IEmailSender, IEmailService
     {
         private readonly EmailSettings _settings;
 

--- a/GameSite/Services/GoogleAuthService.cs
+++ b/GameSite/Services/GoogleAuthService.cs
@@ -1,0 +1,22 @@
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Authentication.Google;
+using GameSite.Models;
+
+namespace GameSite.Services
+{
+    public class GoogleAuthService : IGoogleAuthService
+    {
+        private readonly SignInManager<ApplicationUser> _signInManager;
+
+        public GoogleAuthService(SignInManager<ApplicationUser> signInManager)
+        {
+            _signInManager = signInManager;
+        }
+
+        public AuthenticationProperties ConfigureExternalAuthenticationProperties(string redirectUrl)
+        {
+            return _signInManager.ConfigureExternalAuthenticationProperties(GoogleDefaults.AuthenticationScheme, redirectUrl);
+        }
+    }
+}

--- a/GameSite/Services/IEmailService.cs
+++ b/GameSite/Services/IEmailService.cs
@@ -1,6 +1,8 @@
+using System.Threading.Tasks;
 namespace GameSite.Services
 {
     public interface IEmailService
     {
+        Task SendEmailAsync(string email, string subject, string htmlMessage);
     }
 }

--- a/GameSite/Services/IGoogleAuthService.cs
+++ b/GameSite/Services/IGoogleAuthService.cs
@@ -1,6 +1,8 @@
+using Microsoft.AspNetCore.Authentication;
 namespace GameSite.Services
 {
     public interface IGoogleAuthService
     {
+        AuthenticationProperties ConfigureExternalAuthenticationProperties(string redirectUrl);
     }
 }

--- a/GameSite/appsettings.Development.json
+++ b/GameSite/appsettings.Development.json
@@ -4,5 +4,11 @@
       "Default": "Information",
       "Microsoft.AspNetCore": "Warning"
     }
+  },
+  "Authentication": {
+    "Google": {
+      "ClientId": "",
+      "ClientSecret": ""
+    }
   }
 }

--- a/GameSite/appsettings.json
+++ b/GameSite/appsettings.json
@@ -15,5 +15,11 @@
     "SmtpPort": 587,
     "FromEmail": "jl_sp_amg@mail.ru",
     "Password": ""
+  },
+  "Authentication": {
+    "Google": {
+      "ClientId": "",
+      "ClientSecret": ""
+    }
   }
 }


### PR DESCRIPTION
## Summary
- allow 4-16 character passwords of letters and digits only via `CustomPasswordValidator`
- implement `IEmailService` and integrate with `EmailSender`
- add Google authentication service and endpoints
- wire up Google login, password validation and email service in `Program.cs`
- add Google auth config placeholders in `appsettings.json`

## Testing
- `dotnet build GameSite.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685abd14960483238e071ecaba332ac7