### PR TITLE
Add auto profile redirect and nickname bonus

### DIFF
--- a/GameSite/Areas/Identity/Pages/Account/Register.cshtml
+++ b/GameSite/Areas/Identity/Pages/Account/Register.cshtml
@@ -1,0 +1,30 @@
+@page
+@model GameSite.Areas.Identity.Pages.Account.RegisterModel
+@{
+    ViewData["Title"] = "Register";
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<form method="post">
+    <div class="mb-3">
+        <label asp-for="Input.Email" class="form-label"></label>
+        <input asp-for="Input.Email" class="form-control" />
+        <span asp-validation-for="Input.Email" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Input.Password" class="form-label"></label>
+        <input asp-for="Input.Password" class="form-control" />
+        <span asp-validation-for="Input.Password" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Input.ConfirmPassword" class="form-label"></label>
+        <input asp-for="Input.ConfirmPassword" class="form-control" />
+        <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Register</button>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/GameSite/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/GameSite/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -1,0 +1,76 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using GameSite.Models;
+
+namespace GameSite.Areas.Identity.Pages.Account
+{
+    public class RegisterModel : PageModel
+    {
+        private readonly SignInManager<ApplicationUser> _signInManager;
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly ILogger<RegisterModel> _logger;
+
+        public RegisterModel(
+            UserManager<ApplicationUser> userManager,
+            SignInManager<ApplicationUser> signInManager,
+            ILogger<RegisterModel> logger)
+        {
+            _userManager = userManager;
+            _signInManager = signInManager;
+            _logger = logger;
+        }
+
+        [BindProperty]
+        public InputModel Input { get; set; } = new();
+
+        public string? ReturnUrl { get; set; }
+
+        public class InputModel
+        {
+            [Required]
+            [EmailAddress]
+            [Display(Name = "Email")]
+            public string Email { get; set; } = string.Empty;
+
+            [Required]
+            [DataType(DataType.Password)]
+            [Display(Name = "Password")]
+            public string Password { get; set; } = string.Empty;
+
+            [DataType(DataType.Password)]
+            [Display(Name = "Confirm password")]
+            [Compare("Password", ErrorMessage = "The password and confirmation password do not match.")]
+            public string ConfirmPassword { get; set; } = string.Empty;
+        }
+
+        public void OnGet(string? returnUrl = null)
+        {
+            ReturnUrl = returnUrl;
+        }
+
+        public async Task<IActionResult> OnPostAsync(string? returnUrl = null)
+        {
+            returnUrl ??= Url.Action("Index", "User");
+            if (ModelState.IsValid)
+            {
+                var user = new ApplicationUser { UserName = Input.Email, Email = Input.Email, RegistrationDate = DateTime.UtcNow };
+                var result = await _userManager.CreateAsync(user, Input.Password);
+                if (result.Succeeded)
+                {
+                    _logger.LogInformation("User created a new account with password.");
+                    await _signInManager.SignInAsync(user, isPersistent: false);
+                    return LocalRedirect(returnUrl!);
+                }
+                foreach (var error in result.Errors)
+                {
+                    ModelState.AddModelError(string.Empty, error.Description);
+                }
+            }
+
+            // If we got this far, something failed, redisplay form
+            return Page();
+        }
+    }
+}

--- a/GameSite/Areas/Identity/Pages/_ViewImports.cshtml
+++ b/GameSite/Areas/Identity/Pages/_ViewImports.cshtml
@@ -1,0 +1,3 @@
+@using GameSite
+@using GameSite.Models
+@addTagHelper *, Microsoft.AspNetCore.Mvc.TagHelpers

--- a/GameSite/Controllers/AccountController.cs
+++ b/GameSite/Controllers/AccountController.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Google;
 using GameSite.Models;
 using GameSite.Services;
+using System.Security.Claims;
 
 namespace GameSite.Controllers
 {

--- a/GameSite/Controllers/UserController.cs
+++ b/GameSite/Controllers/UserController.cs
@@ -50,6 +50,8 @@ namespace GameSite.Controllers
 
             if (!string.Equals(user.UserName, model.UserName, StringComparison.Ordinal))
             {
+                bool wasEmail = string.Equals(user.UserName, user.Email, StringComparison.OrdinalIgnoreCase);
+
                 var setNameResult = await _userManager.SetUserNameAsync(user, model.UserName);
                 if (!setNameResult.Succeeded)
                 {
@@ -58,6 +60,11 @@ namespace GameSite.Controllers
                         ModelState.AddModelError(string.Empty, error.Description);
                     }
                     return View(model);
+                }
+
+                if (wasEmail)
+                {
+                    user.Balance += 100;
                 }
             }
 

--- a/GameSite/GameSite.csproj
+++ b/GameSite/GameSite.csproj
@@ -12,6 +12,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="8.0.16" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="8.0.16" />
     <PackageReference Include="Microsoft.AspNetCore.Identity.UI" Version="8.0.16" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Google" Version="8.0.16" />
     <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.11" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="8.0.16" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.22.1-Preview.1" />

--- a/GameSite/Program.cs
+++ b/GameSite/Program.cs
@@ -23,7 +23,7 @@ namespace GameSite
 
             builder.Services.AddDefaultIdentity<ApplicationUser>(options =>
             {
-                options.SignIn.RequireConfirmedAccount = true;
+                options.SignIn.RequireConfirmedAccount = false;
                 options.Password.RequiredLength = 4;
                 options.Password.RequireNonAlphanumeric = false;
                 options.Password.RequireLowercase = false;

--- a/GameSite/Views/User/Index.cshtml
+++ b/GameSite/Views/User/Index.cshtml
@@ -7,6 +7,7 @@
 @if (Model != null)
 {
     <p>UserName: @Model.UserName</p>
+    <p>Balance: @Model.Balance.ToString("0") GameCoins</p>
     <p>XP: @Model.XP</p>
     <p>Rank: @Model.Rank</p>
     <a asp-action="Edit" class="btn btn-primary">Edit profile</a>


### PR DESCRIPTION
## Summary
- scaffold register page so new users are signed in immediately and redirected to their profile
- disable confirm-account requirement
- award 100 GameCoins on first nickname change
- show coin balance on profile
- add missing Google auth package

## Testing
- `dotnet build GameSite/GameSite.csproj`

------
https://chatgpt.com/codex/tasks/task_e_685abf67bdfc8323bba6b9316001210d