### PR TITLE
Add unique friend ID and dynamic search

### DIFF
--- a/GameSite/Areas/Identity/Pages/Account/Register.cshtml.cs
+++ b/GameSite/Areas/Identity/Pages/Account/Register.cshtml.cs
@@ -55,7 +55,14 @@ namespace GameSite.Areas.Identity.Pages.Account
             returnUrl ??= Url.Action("Index", "User");
             if (ModelState.IsValid)
             {
-                var user = new ApplicationUser { UserName = Input.Email, Email = Input.Email, RegistrationDate = DateTime.UtcNow };
+                string uid;
+                do
+                {
+                    uid = Guid.NewGuid().ToString("N").Substring(0, 8);
+                }
+                while (_userManager.Users.Any(u => u.UniqueId == uid));
+
+                var user = new ApplicationUser { UserName = Input.Email, Email = Input.Email, RegistrationDate = DateTime.UtcNow, UniqueId = uid };
                 var result = await _userManager.CreateAsync(user, Input.Password);
                 if (result.Succeeded)
                 {

--- a/GameSite/Controllers/SearchController.cs
+++ b/GameSite/Controllers/SearchController.cs
@@ -1,0 +1,38 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using GameSite.Models;
+using System.Linq;
+
+namespace GameSite.Controllers
+{
+    [Authorize]
+    [ApiController]
+    [Route("[controller]")]
+    public class SearchController : Controller
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public SearchController(UserManager<ApplicationUser> userManager)
+        {
+            _userManager = userManager;
+        }
+
+        [HttpGet("Users")]
+        public IActionResult Users(string query)
+        {
+            if (string.IsNullOrWhiteSpace(query))
+            {
+                return Json(Array.Empty<object>());
+            }
+
+            var users = _userManager.Users
+                .Where(u => u.UserName!.Contains(query) || u.Email!.Contains(query) || u.UniqueId.Contains(query))
+                .Select(u => new { u.Id, u.UserName })
+                .Take(10)
+                .ToList();
+
+            return Json(users);
+        }
+    }
+}

--- a/GameSite/Data/ApplicationDbContext.cs
+++ b/GameSite/Data/ApplicationDbContext.cs
@@ -20,6 +20,10 @@ namespace GameSite.Data
             base.OnModelCreating(builder);
 
             builder.Entity<ApplicationUser>()
+                .HasIndex(u => u.UniqueId)
+                .IsUnique();
+
+            builder.Entity<ApplicationUser>()
                 .HasMany(u => u.Friends)
                 .WithOne(f => f.User)
                 .HasForeignKey(f => f.UserId)

--- a/GameSite/Data/Migrations/20250626120000_AddUniqueIdToUsers.cs
+++ b/GameSite/Data/Migrations/20250626120000_AddUniqueIdToUsers.cs
@@ -1,0 +1,39 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace GameSite.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddUniqueIdToUsers : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "UniqueId",
+                table: "AspNetUsers",
+                type: "text",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_AspNetUsers_UniqueId",
+                table: "AspNetUsers",
+                column: "UniqueId",
+                unique: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_AspNetUsers_UniqueId",
+                table: "AspNetUsers");
+
+            migrationBuilder.DropColumn(
+                name: "UniqueId",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/GameSite/Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/GameSite/Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -92,6 +92,10 @@ namespace GameSite.Data.Migrations
                         .HasMaxLength(256)
                         .HasColumnType("character varying(256)");
 
+                    b.Property<string>("UniqueId")
+                        .IsRequired()
+                        .HasColumnType("text");
+
                     b.Property<int>("XP")
                         .HasColumnType("integer");
 
@@ -103,6 +107,9 @@ namespace GameSite.Data.Migrations
                     b.HasIndex("NormalizedUserName")
                         .IsUnique()
                         .HasDatabaseName("UserNameIndex");
+
+                    b.HasIndex("UniqueId")
+                        .IsUnique();
 
                     b.ToTable("AspNetUsers", (string)null);
                 });

--- a/GameSite/Models/ApplicationUser.cs
+++ b/GameSite/Models/ApplicationUser.cs
@@ -6,6 +6,7 @@ namespace GameSite.Models
 {
     public class ApplicationUser : IdentityUser
     {
+        public string UniqueId { get; set; } = Guid.NewGuid().ToString("N").Substring(0, 8);
         public string? AvatarPath { get; set; }
         public decimal Balance { get; set; }
         public DateTime RegistrationDate { get; set; }

--- a/GameSite/Views/Shared/_Layout.cshtml
+++ b/GameSite/Views/Shared/_Layout.cshtml
@@ -47,6 +47,13 @@
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
                         </li>
                     </ul>
+                    @if (User.Identity?.IsAuthenticated ?? false)
+                    {
+                        <div class="d-flex position-relative me-2">
+                            <input id="user-search" class="form-control" type="search" placeholder="Find players" autocomplete="off" />
+                            <div id="search-results" class="list-group position-absolute"></div>
+                        </div>
+                    }
                     <partial name="_LoginPartial" />
                 </div>
             </div>

--- a/GameSite/Views/User/Index.cshtml
+++ b/GameSite/Views/User/Index.cshtml
@@ -7,6 +7,8 @@
 @if (Model != null)
 {
     <p>UserName: @Model.UserName</p>
+    <p>Your ID: @Model.UniqueId</p>
+    <p>Email: @Model.Email</p>
     <p>Balance: @Model.Balance.ToString("0") GameCoins</p>
     <p>XP: @Model.XP</p>
     <p>Rank: @Model.Rank</p>

--- a/GameSite/wwwroot/css/site.css
+++ b/GameSite/wwwroot/css/site.css
@@ -20,3 +20,12 @@ html {
 body {
   margin-bottom: 60px;
 }
+
+#search-results {
+  background-color: #fff;
+  border: 1px solid #ced4da;
+  max-height: 200px;
+  overflow-y: auto;
+  width: 100%;
+  z-index: 1000;
+}

--- a/GameSite/wwwroot/js/site.js
+++ b/GameSite/wwwroot/js/site.js
@@ -2,3 +2,38 @@
 // for details on configuring this project to bundle and minify static web assets.
 
 // Write your JavaScript code.
+
+const searchInput = document.getElementById('user-search');
+const resultsContainer = document.getElementById('search-results');
+
+if (searchInput && resultsContainer) {
+    searchInput.addEventListener('input', async () => {
+        const query = searchInput.value.trim();
+        if (!query) {
+            resultsContainer.innerHTML = '';
+            return;
+        }
+
+        const res = await fetch(`/Search/Users?query=${encodeURIComponent(query)}`);
+        if (!res.ok) return;
+        const users = await res.json();
+        resultsContainer.innerHTML = '';
+        users.forEach(u => {
+            const div = document.createElement('div');
+            div.className = 'list-group-item d-flex justify-content-between align-items-center';
+            div.textContent = u.userName;
+            const btn = document.createElement('button');
+            btn.className = 'btn btn-sm btn-primary ms-2';
+            btn.textContent = 'Add';
+            btn.addEventListener('click', async () => {
+                await fetch('/Friends/Add', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                    body: `friendId=${encodeURIComponent(u.id)}`
+                });
+            });
+            div.appendChild(btn);
+            resultsContainer.appendChild(div);
+        });
+    });
+}


### PR DESCRIPTION
## Summary
- add `UniqueId` field to users
- store UniqueId with unique DB index
- generate UniqueId during registration
- expose UniqueId on profile page only
- implement search endpoint and navbar search bar
- add styles and script for dynamic friend search
- create EF migration

## Testing
- `dotnet build GameSite/GameSite.csproj -c Release` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ac362ff888323a64809cdf6ee2a69