### PR TITLE
Handle missing Google OAuth credentials

### DIFF
--- a/GameSite/Program.cs
+++ b/GameSite/Program.cs
@@ -37,13 +37,18 @@ namespace GameSite
             builder.Services.AddTransient<IEmailSender, EmailSender>();
             builder.Services.AddTransient<IEmailService, EmailSender>();
             builder.Services.AddTransient<IGoogleAuthService, GoogleAuthService>();
-            builder.Services.AddAuthentication()
-                .AddGoogle(options =>
+            var authenticationBuilder = builder.Services.AddAuthentication();
+            var googleAuth = builder.Configuration.GetSection("Authentication:Google");
+            var clientId = googleAuth["ClientId"];
+            var clientSecret = googleAuth["ClientSecret"];
+            if (!string.IsNullOrEmpty(clientId) && !string.IsNullOrEmpty(clientSecret))
+            {
+                authenticationBuilder.AddGoogle(options =>
                 {
-                    var googleAuth = builder.Configuration.GetSection("Authentication:Google");
-                    options.ClientId = googleAuth["ClientId"]!;
-                    options.ClientSecret = googleAuth["ClientSecret"]!;
+                    options.ClientId = clientId;
+                    options.ClientSecret = clientSecret;
                 });
+            }
             builder.Services.AddControllersWithViews();
 
             var app = builder.Build();

--- a/README.md
+++ b/README.md
@@ -1,0 +1,5 @@
+# GameSite
+
+This project is an ASP.NET Core web application. For Google authentication to work you need to provide the OAuth `ClientId` and `ClientSecret`.
+
+Add them in `appsettings.Development.json` or provide them via environment variables when deploying. If these values are not set, Google authentication is skipped and the rest of the application will still run.


### PR DESCRIPTION
## Summary
- handle Google client id/secret missing when starting app
- document optional Google credentials

## Testing
- `dotnet build GameSite/GameSite.csproj -v minimal` *(fails: dotnet not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ad4f5c3f08323acc38d5e64ace715