### PR TITLE
Add 2FA QR code setup page

### DIFF
--- a/GameSite/Areas/Identity/Pages/Account/Manage/EnableAuthenticator.cshtml
+++ b/GameSite/Areas/Identity/Pages/Account/Manage/EnableAuthenticator.cshtml
@@ -1,0 +1,39 @@
+@page
+@model GameSite.Areas.Identity.Pages.Account.Manage.EnableAuthenticatorModel
+@{
+    ViewData["Title"] = "Authenticator app";
+}
+
+<h3>@ViewData["Title"]</h3>
+
+<p>Scan the QR code with your authenticator app, or enter the key manually.</p>
+
+<div class="mb-3">
+    <label class="form-label">Key</label>
+    <input type="text" class="form-control" value="@Model.SharedKey" readonly />
+</div>
+
+<div id="qr-code" class="mb-3"></div>
+
+<form method="post">
+    <div class="mb-3">
+        <label asp-for="Input.Code" class="form-label"></label>
+        <input asp-for="Input.Code" class="form-control" autocomplete="off" />
+        <span asp-validation-for="Input.Code" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Verify</button>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+    <script src="~/lib/davidshimjs-qrcodejs-04f46c6/qrcode.min.js"></script>
+    <script>
+        (function () {
+            var qrcode = new QRCode(document.getElementById('qr-code'), {
+                width: 200,
+                height: 200
+            });
+            qrcode.makeCode('@Model.AuthenticatorUri');
+        })();
+    </script>
+}

--- a/GameSite/Areas/Identity/Pages/Account/Manage/EnableAuthenticator.cshtml.cs
+++ b/GameSite/Areas/Identity/Pages/Account/Manage/EnableAuthenticator.cshtml.cs
@@ -1,0 +1,126 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text;
+using System.Text.Encodings.Web;
+using GameSite.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GameSite.Areas.Identity.Pages.Account.Manage
+{
+    [Authorize]
+    public class EnableAuthenticatorModel : PageModel
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly ILogger<EnableAuthenticatorModel> _logger;
+        private readonly UrlEncoder _urlEncoder;
+
+        private const string AuthenticatorUriFormat = "otpauth://totp/{0}:{1}?secret={2}&issuer={0}&digits=6";
+
+        public EnableAuthenticatorModel(UserManager<ApplicationUser> userManager, ILogger<EnableAuthenticatorModel> logger, UrlEncoder urlEncoder)
+        {
+            _userManager = userManager;
+            _logger = logger;
+            _urlEncoder = urlEncoder;
+        }
+
+        [BindProperty]
+        public InputModel Input { get; set; } = new();
+
+        public string SharedKey { get; set; } = string.Empty;
+
+        public string AuthenticatorUri { get; set; } = string.Empty;
+
+        public class InputModel
+        {
+            [Required]
+            [StringLength(7, MinimumLength = 6)]
+            [DataType(DataType.Text)]
+            [Display(Name = "Verification Code")]
+            public string Code { get; set; } = string.Empty;
+        }
+
+        public async Task<IActionResult> OnGetAsync()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null)
+            {
+                return NotFound("Unable to load user.");
+            }
+
+            await LoadSharedKeyAndQrCodeUriAsync(user);
+
+            return Page();
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null)
+            {
+                return NotFound("Unable to load user.");
+            }
+
+            if (!ModelState.IsValid)
+            {
+                await LoadSharedKeyAndQrCodeUriAsync(user);
+                return Page();
+            }
+
+            var verificationCode = Input.Code.Replace(" ", string.Empty).Replace("-", string.Empty);
+
+            var is2faTokenValid = await _userManager.VerifyTwoFactorTokenAsync(
+                user, _userManager.Options.Tokens.AuthenticatorTokenProvider, verificationCode);
+
+            if (!is2faTokenValid)
+            {
+                ModelState.AddModelError("Input.Code", "Verification code is invalid.");
+                await LoadSharedKeyAndQrCodeUriAsync(user);
+                return Page();
+            }
+
+            await _userManager.SetTwoFactorEnabledAsync(user, true);
+            _logger.LogInformation("User enabled 2FA with an authenticator app.");
+
+            return RedirectToPage("./TwoFactorAuthentication");
+        }
+
+        private async Task LoadSharedKeyAndQrCodeUriAsync(ApplicationUser user)
+        {
+            var unformattedKey = await _userManager.GetAuthenticatorKeyAsync(user);
+            if (string.IsNullOrEmpty(unformattedKey))
+            {
+                await _userManager.ResetAuthenticatorKeyAsync(user);
+                unformattedKey = await _userManager.GetAuthenticatorKeyAsync(user);
+            }
+
+            SharedKey = FormatKey(unformattedKey);
+            AuthenticatorUri = GenerateQrCodeUri(user.Email!, unformattedKey);
+        }
+
+        private static string FormatKey(string unformattedKey)
+        {
+            var result = new StringBuilder();
+            for (int i = 0; i + 4 < unformattedKey.Length; i += 4)
+            {
+                result.Append(unformattedKey.AsSpan(i, 4)).Append(' ');
+            }
+            int remaining = unformattedKey.Length % 4;
+            if (remaining != 0)
+            {
+                result.Append(unformattedKey.AsSpan(unformattedKey.Length - remaining));
+            }
+            return result.ToString().ToLowerInvariant();
+        }
+
+        private string GenerateQrCodeUri(string email, string unformattedKey)
+        {
+            return string.Format(
+                AuthenticatorUriFormat,
+                _urlEncoder.Encode("GameSite"),
+                _urlEncoder.Encode(email),
+                unformattedKey);
+        }
+    }
+}

--- a/GameSite/Areas/Identity/Pages/Account/Manage/TwoFactorAuthentication.cshtml
+++ b/GameSite/Areas/Identity/Pages/Account/Manage/TwoFactorAuthentication.cshtml
@@ -1,0 +1,17 @@
+@page
+@model GameSite.Areas.Identity.Pages.Account.Manage.TwoFactorAuthenticationModel
+@{
+    ViewData["Title"] = "Two-factor authentication (2FA)";
+}
+
+<h3>@ViewData["Title"]</h3>
+
+@if (Model.Is2faEnabled)
+{
+    <p>Two-factor authentication is enabled.</p>
+}
+else
+{
+    <p>Two-factor authentication is not enabled.</p>
+    <a asp-page="./EnableAuthenticator" class="btn btn-primary">Setup Authenticator app</a>
+}

--- a/GameSite/Areas/Identity/Pages/Account/Manage/TwoFactorAuthentication.cshtml.cs
+++ b/GameSite/Areas/Identity/Pages/Account/Manage/TwoFactorAuthentication.cshtml.cs
@@ -1,0 +1,33 @@
+using GameSite.Models;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+
+namespace GameSite.Areas.Identity.Pages.Account.Manage
+{
+    [Authorize]
+    public class TwoFactorAuthenticationModel : PageModel
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public bool Is2faEnabled { get; set; }
+
+        public TwoFactorAuthenticationModel(UserManager<ApplicationUser> userManager)
+        {
+            _userManager = userManager;
+        }
+
+        public async Task<IActionResult> OnGetAsync()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null)
+            {
+                return NotFound("Unable to load user.");
+            }
+
+            Is2faEnabled = await _userManager.GetTwoFactorEnabledAsync(user);
+            return Page();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add TwoFactorAuthentication and EnableAuthenticator pages for 2FA
- generate QR codes client-side with qrcodejs library

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685ae811653883238034660001b431a5