### PR TITLE
Fix username email bug and add theme switcher

### DIFF
--- a/GameSite/Controllers/UserController.cs
+++ b/GameSite/Controllers/UserController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Http;
 using System;
 using System.IO;
 using System.Linq;
+using System.ComponentModel.DataAnnotations;
 
 namespace GameSite.Controllers
 {
@@ -120,6 +121,12 @@ namespace GameSite.Controllers
 
             if (!string.Equals(user.UserName, model.UserName, StringComparison.Ordinal))
             {
+                if (new EmailAddressAttribute().IsValid(model.UserName))
+                {
+                    ModelState.AddModelError("UserName", "Username cannot be an email address.");
+                    return View(model);
+                }
+
                 bool wasEmail = string.Equals(user.UserName, user.Email, StringComparison.OrdinalIgnoreCase);
 
                 var setNameResult = await _userManager.SetUserNameAsync(user, model.UserName);

--- a/GameSite/Views/Shared/_Layout.cshtml
+++ b/GameSite/Views/Shared/_Layout.cshtml
@@ -54,6 +54,16 @@
                             <div id="search-results" class="list-group position-absolute"></div>
                         </div>
                     }
+                    <div class="dropdown me-2">
+                        <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="themeDropdown" data-bs-toggle="dropdown" aria-expanded="false">
+                            Theme
+                        </button>
+                        <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="themeDropdown">
+                            <li><a class="dropdown-item" href="#" data-theme-value="light">Day</a></li>
+                            <li><a class="dropdown-item" href="#" data-theme-value="dark">Night</a></li>
+                            <li><a class="dropdown-item" href="#" data-theme-value="system">System</a></li>
+                        </ul>
+                    </div>
                     <partial name="_LoginPartial" />
                 </div>
             </div>

--- a/GameSite/wwwroot/css/site.css
+++ b/GameSite/wwwroot/css/site.css
@@ -29,3 +29,17 @@ body {
   width: 100%;
   z-index: 1000;
 }
+
+[data-theme="dark"] {
+  background-color: #121212;
+  color: #ffffff;
+}
+
+[data-theme="dark"] .navbar {
+  background-color: #333333;
+}
+
+[data-theme="dark"] .dropdown-menu {
+  background-color: #333333;
+  color: #ffffff;
+}

--- a/GameSite/wwwroot/js/site.js
+++ b/GameSite/wwwroot/js/site.js
@@ -37,3 +37,41 @@ if (searchInput && resultsContainer) {
         });
     });
 }
+
+// Theme switcher
+function getStoredTheme() {
+    return localStorage.getItem('theme');
+}
+
+function getPreferredTheme() {
+    const stored = getStoredTheme();
+    if (stored) {
+        return stored;
+    }
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+}
+
+function applyTheme(theme) {
+    document.documentElement.setAttribute('data-theme', theme);
+}
+
+applyTheme(getPreferredTheme());
+
+window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    if (!getStoredTheme()) {
+        applyTheme(getPreferredTheme());
+    }
+});
+
+document.querySelectorAll('[data-theme-value]').forEach(btn => {
+    btn.addEventListener('click', e => {
+        e.preventDefault();
+        const theme = btn.getAttribute('data-theme-value');
+        if (theme === 'system') {
+            localStorage.removeItem('theme');
+        } else {
+            localStorage.setItem('theme', theme);
+        }
+        applyTheme(getPreferredTheme());
+    });
+});


### PR DESCRIPTION
## Summary
- prevent using email addresses as usernames in profile edit
- allow users to switch themes (Day/Night/System)
- basic dark theme styles

## Testing
- `dotnet build GameSite/GameSite.csproj -nologo`

------
https://chatgpt.com/codex/tasks/task_e_685af0571d84832385acda259be301d8