### PR TITLE
Improve dark theme support

### DIFF
--- a/GameSite/Views/Shared/_Layout.cshtml
+++ b/GameSite/Views/Shared/_Layout.cshtml
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/GameSite.styles.css" asp-append-version="true" />
 </head>
-<body>
+<body class="theme-light">
     <header>
         <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
             <div class="container-fluid">

--- a/GameSite/wwwroot/css/site.css
+++ b/GameSite/wwwroot/css/site.css
@@ -43,3 +43,35 @@ body {
   background-color: #333333;
   color: #ffffff;
 }
+.theme-light {
+  background-color: #ffffff;
+  color: #000000;
+}
+
+.theme-dark {
+  background-color: #121212;
+  color: #ffffff;
+}
+
+.theme-dark .navbar {
+  background-color: #333333;
+}
+
+.theme-dark .dropdown-menu {
+  background-color: #333333;
+  color: #ffffff;
+}
+
+.theme-dark .nav-link,
+.theme-dark .navbar-brand,
+.theme-dark .text-dark {
+  color: #ffffff !important;
+}
+
+.theme-dark .text-muted {
+  color: #cccccc !important;
+}
+
+.theme-dark .bg-white {
+  background-color: #1f1f1f !important;
+}

--- a/GameSite/wwwroot/js/site.js
+++ b/GameSite/wwwroot/js/site.js
@@ -52,7 +52,9 @@ function getPreferredTheme() {
 }
 
 function applyTheme(theme) {
-    document.documentElement.setAttribute('data-theme', theme);
+    document.documentElement.setAttribute("data-theme", theme);
+    document.documentElement.classList.remove("theme-dark", "theme-light");
+    document.documentElement.classList.add(theme === "dark" ? "theme-dark" : "theme-light");
 }
 
 applyTheme(getPreferredTheme());


### PR DESCRIPTION
## Summary
- add base theme classes for light/dark
- switch `<body>` to use theme class
- enhance theme toggle script to add theme classes

## Testing
- `dotnet build GameSite.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af2e265488323ba21f49808aeda94