### PR TITLE
Fix dark theme not applying to full page

### DIFF
--- a/GameSite/Views/Shared/_Layout.cshtml
+++ b/GameSite/Views/Shared/_Layout.cshtml
@@ -8,7 +8,7 @@
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
     <link rel="stylesheet" href="~/GameSite.styles.css" asp-append-version="true" />
 </head>
-<body class="theme-light">
+<body>
     <header>
         <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
             <div class="container-fluid">

--- a/GameSite/wwwroot/css/site.css
+++ b/GameSite/wwwroot/css/site.css
@@ -30,7 +30,8 @@ body {
   z-index: 1000;
 }
 
-[data-theme="dark"] {
+[data-theme="dark"],
+[data-theme="dark"] body {
   background-color: #121212;
   color: #ffffff;
 }
@@ -43,12 +44,14 @@ body {
   background-color: #333333;
   color: #ffffff;
 }
-.theme-light {
+.theme-light,
+.theme-light body {
   background-color: #ffffff;
   color: #000000;
 }
 
-.theme-dark {
+.theme-dark,
+.theme-dark body {
   background-color: #121212;
   color: #ffffff;
 }

--- a/GameSite/wwwroot/js/site.js
+++ b/GameSite/wwwroot/js/site.js
@@ -53,8 +53,12 @@ function getPreferredTheme() {
 
 function applyTheme(theme) {
     document.documentElement.setAttribute("data-theme", theme);
+    document.body.setAttribute("data-theme", theme);
     document.documentElement.classList.remove("theme-dark", "theme-light");
-    document.documentElement.classList.add(theme === "dark" ? "theme-dark" : "theme-light");
+    document.body.classList.remove("theme-dark", "theme-light");
+    const cls = theme === "dark" ? "theme-dark" : "theme-light";
+    document.documentElement.classList.add(cls);
+    document.body.classList.add(cls);
 }
 
 applyTheme(getPreferredTheme());


### PR DESCRIPTION
## Summary
- remove default `theme-light` class from body
- apply theme classes and attribute to both `html` and `body`
- ensure CSS rules style `body` element in dark mode

## Testing
- `dotnet build --no-restore` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685af5f857fc8323a58464636bc0ec81