### PR TITLE
Fix posts variable and nullability warning

### DIFF
--- a/GameSite/Areas/Identity/Pages/Account/Manage/EnableAuthenticator.cshtml.cs
+++ b/GameSite/Areas/Identity/Pages/Account/Manage/EnableAuthenticator.cshtml.cs
@@ -95,8 +95,8 @@ namespace GameSite.Areas.Identity.Pages.Account.Manage
                 unformattedKey = await _userManager.GetAuthenticatorKeyAsync(user);
             }
 
-            SharedKey = FormatKey(unformattedKey);
-            AuthenticatorUri = GenerateQrCodeUri(user.Email!, unformattedKey);
+            SharedKey = FormatKey(unformattedKey!);
+            AuthenticatorUri = GenerateQrCodeUri(user.Email!, unformattedKey!);
         }
 
         private static string FormatKey(string unformattedKey)

--- a/GameSite/Controllers/UserController.cs
+++ b/GameSite/Controllers/UserController.cs
@@ -49,13 +49,6 @@ namespace GameSite.Controllers
                 .OrderByDescending(p => p.Created)
                 .ToListAsync();
 
-            var posts = await _context.Posts
-                .Include(p => p.User)
-                .Include(p => p.Likes)
-                .Where(p => p.UserId == user.Id)
-                .OrderByDescending(p => p.Created)
-                .ToListAsync();
-
             var model = new UserProfileViewModel
             {
                 User = user,
@@ -85,6 +78,13 @@ namespace GameSite.Controllers
             var friends = await _context.Friends
                 .Include(f => f.FriendUser)
                 .Where(f => f.UserId == user.Id)
+                .ToListAsync();
+
+            var posts = await _context.Posts
+                .Include(p => p.User)
+                .Include(p => p.Likes)
+                .Where(p => p.UserId == user.Id)
+                .OrderByDescending(p => p.Created)
                 .ToListAsync();
 
             var model = new UserProfileViewModel


### PR DESCRIPTION
## Summary
- remove duplicate `posts` variable and fetch posts for profile details
- apply null-forgiving operator when formatting authenticator key

## Testing
- `dotnet build GameSite.sln`
- `dotnet test GameSite.sln`

------
https://chatgpt.com/codex/tasks/task_e_685afbe999cc8323b2b9f8920ad91d76