### PR TITLE
Enable post deletion and length limit

### DIFF
--- a/GameSite/Models/Post.cs
+++ b/GameSite/Models/Post.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 
 namespace GameSite.Models
 {
@@ -7,6 +8,7 @@ namespace GameSite.Models
         public int Id { get; set; }
         public string? UserId { get; set; }
         public ApplicationUser? User { get; set; }
+        [MaxLength(2000)]
         public string Content { get; set; } = string.Empty;
         public string? MediaUrl { get; set; }
         public DateTime Created { get; set; }

--- a/GameSite/Views/Feed/Index.cshtml
+++ b/GameSite/Views/Feed/Index.cshtml
@@ -17,7 +17,7 @@
             <div class="modal-body">
                 <form id="create-post-form" asp-controller="Post" asp-action="Create" method="post" enctype="multipart/form-data">
                     <input type="hidden" name="returnUrl" value="@Url.Action("Index", "Feed")" />
-                    <textarea name="content" class="form-control" rows="2" placeholder="Write something..."></textarea>
+                    <textarea name="content" class="form-control" rows="2" placeholder="Write something..." maxlength="2000"></textarea>
                     <input type="file" name="mediaFile" class="form-control mt-2" />
                     <input type="text" name="link" class="form-control mt-2" placeholder="Link (optional)" />
                 </form>

--- a/GameSite/Views/Post/Index.cshtml
+++ b/GameSite/Views/Post/Index.cshtml
@@ -4,7 +4,7 @@
 }
 
 <form asp-action="Create" method="post" enctype="multipart/form-data" class="mb-3">
-    <textarea name="content" class="form-control" rows="2" placeholder="Write something..."></textarea>
+    <textarea name="content" class="form-control" rows="2" placeholder="Write something..." maxlength="2000"></textarea>
     <input type="file" name="mediaFile" class="form-control mt-2" />
     <input type="text" name="link" class="form-control mt-2" placeholder="Link (optional)" />
     <button type="submit" class="btn btn-primary mt-2">Post</button>

--- a/GameSite/Views/Shared/_PostList.cshtml
+++ b/GameSite/Views/Shared/_PostList.cshtml
@@ -13,7 +13,17 @@
         </div>
         @if (!string.IsNullOrEmpty(post.Content))
         {
-            <p>@post.Content</p>
+            if (post.Content.Length > 500)
+            {
+                <p>
+                    @post.Content.Substring(0, 500)<span class="ellipsis">...</span><span class="more-text d-none">@post.Content.Substring(500)</span>
+                    <a href="#" class="read-more">(ещё..)</a>
+                </p>
+            }
+            else
+            {
+                <p>@post.Content</p>
+            }
         }
         @if (!string.IsNullOrEmpty(post.MediaUrl))
         {
@@ -37,9 +47,15 @@
             var currentId = UserManager.GetUserId(User);
             bool liked = post.Likes?.Any(l => l.UserId == currentId) == true;
         }
-        <form asp-controller="Post" asp-action="Like" method="post" asp-route-postId="@post.Id" class="like-form">
+        <form asp-controller="Post" asp-action="Like" method="post" asp-route-postId="@post.Id" class="like-form d-inline">
             <button type="submit" class="btn btn-link p-0 like-btn" data-post-id="@post.Id">@(liked ? "Unlike" : "Like") (@post.Likes?.Count ?? 0)</button>
         </form>
+        @if (currentId == post.UserId)
+        {
+            <form asp-controller="Post" asp-action="Delete" method="post" asp-route-id="@post.Id" class="d-inline ms-2" onsubmit="return confirm('Delete this post?');">
+                <button type="submit" class="btn btn-sm btn-danger">Delete</button>
+            </form>
+        }
     </li>
 }
 </ul>

--- a/GameSite/wwwroot/js/site.js
+++ b/GameSite/wwwroot/js/site.js
@@ -103,4 +103,14 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
     });
+
+    document.querySelectorAll('.read-more').forEach(link => {
+        link.addEventListener('click', e => {
+            e.preventDefault();
+            const p = link.parentElement;
+            p.querySelector('.more-text').classList.remove('d-none');
+            p.querySelector('.ellipsis').classList.add('d-none');
+            link.remove();
+        });
+    });
 });


### PR DESCRIPTION
## Summary
- allow authors to delete posts
- limit post length to 2000 characters
- show '(ещё..)' link for posts longer than 500 characters
- add UI limits on text area

## Testing
- `dotnet build GameSite/GameSite.csproj -nologo`
- `dotnet test GameSite/GameSite.csproj -nologo`

------
https://chatgpt.com/codex/tasks/task_e_685b0dde86cc83238896e5d61b8b5870