### PR TITLE
Add email visibility option and google login page

### DIFF
--- a/GameSite/Areas/Identity/Pages/Account/Login.cshtml
+++ b/GameSite/Areas/Identity/Pages/Account/Login.cshtml
@@ -1,0 +1,30 @@
+@page
+@model GameSite.Areas.Identity.Pages.Account.LoginModel
+@{
+    ViewData["Title"] = "Log in";
+}
+
+<h1>@ViewData["Title"]</h1>
+
+<form method="post">
+    <div class="mb-3">
+        <label asp-for="Input.Email" class="form-label"></label>
+        <input asp-for="Input.Email" class="form-control" />
+        <span asp-validation-for="Input.Email" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Input.Password" class="form-label"></label>
+        <input asp-for="Input.Password" class="form-control" />
+        <span asp-validation-for="Input.Password" class="text-danger"></span>
+    </div>
+    <div class="mb-3 form-check">
+        <input asp-for="Input.RememberMe" class="form-check-input" />
+        <label asp-for="Input.RememberMe" class="form-check-label"></label>
+    </div>
+    <button type="submit" class="btn btn-primary">Log in</button>
+    <a asp-controller="Account" asp-action="GoogleLogin" class="btn btn-danger ms-2">Google</a>
+</form>
+
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/GameSite/Areas/Identity/Pages/Account/Login.cshtml.cs
+++ b/GameSite/Areas/Identity/Pages/Account/Login.cshtml.cs
@@ -1,0 +1,62 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using GameSite.Models;
+
+namespace GameSite.Areas.Identity.Pages.Account
+{
+    public class LoginModel : PageModel
+    {
+        private readonly SignInManager<ApplicationUser> _signInManager;
+
+        public LoginModel(SignInManager<ApplicationUser> signInManager)
+        {
+            _signInManager = signInManager;
+        }
+
+        [BindProperty]
+        public InputModel Input { get; set; } = new();
+
+        public string? ReturnUrl { get; set; }
+
+        public class InputModel
+        {
+            [Required]
+            [EmailAddress]
+            public string Email { get; set; } = string.Empty;
+
+            [Required]
+            [DataType(DataType.Password)]
+            public string Password { get; set; } = string.Empty;
+
+            [Display(Name = "Remember me?")]
+            public bool RememberMe { get; set; }
+        }
+
+        public void OnGet(string? returnUrl = null)
+        {
+            ReturnUrl = returnUrl;
+        }
+
+        public async Task<IActionResult> OnPostAsync(string? returnUrl = null)
+        {
+            returnUrl ??= Url.Content("~/");
+            if (ModelState.IsValid)
+            {
+                var result = await _signInManager.PasswordSignInAsync(Input.Email, Input.Password, Input.RememberMe, lockoutOnFailure: false);
+                if (result.Succeeded)
+                {
+                    return LocalRedirect(returnUrl);
+                }
+                if (result.IsLockedOut)
+                {
+                    ModelState.AddModelError(string.Empty, "User locked out.");
+                    return Page();
+                }
+                ModelState.AddModelError(string.Empty, "Invalid login attempt.");
+            }
+            return Page();
+        }
+    }
+}

--- a/GameSite/Controllers/UserController.cs
+++ b/GameSite/Controllers/UserController.cs
@@ -215,6 +215,26 @@ namespace GameSite.Controllers
                 await _userManager.UpdateAsync(user);
                 await _signInManager.RefreshSignInAsync(user);
             }
+
+            if (Request.Headers["X-Requested-With"] == "XMLHttpRequest")
+            {
+                return Ok();
+            }
+
+            return RedirectToAction(nameof(Index));
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> ToggleEmailVisibility(bool isPublic)
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user != null)
+            {
+                user.IsEmailPublic = isPublic;
+                await _userManager.UpdateAsync(user);
+                await _signInManager.RefreshSignInAsync(user);
+            }
+
             return RedirectToAction(nameof(Index));
         }
     }

--- a/GameSite/Data/Migrations/20250625130000_EmailVisibility.cs
+++ b/GameSite/Data/Migrations/20250625130000_EmailVisibility.cs
@@ -1,0 +1,24 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+namespace GameSite.Data.Migrations
+{
+    public partial class EmailVisibility : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsEmailPublic",
+                table: "AspNetUsers",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsEmailPublic",
+                table: "AspNetUsers");
+        }
+    }
+}

--- a/GameSite/Data/Migrations/ApplicationDbContextModelSnapshot.cs
+++ b/GameSite/Data/Migrations/ApplicationDbContextModelSnapshot.cs
@@ -99,6 +99,9 @@ namespace GameSite.Data.Migrations
                     b.Property<int>("XP")
                         .HasColumnType("integer");
 
+                    b.Property<bool>("IsEmailPublic")
+                        .HasColumnType("boolean");
+
                     b.HasKey("Id");
 
                     b.HasIndex("NormalizedEmail")

--- a/GameSite/Models/ApplicationUser.cs
+++ b/GameSite/Models/ApplicationUser.cs
@@ -17,6 +17,8 @@ namespace GameSite.Models
         public int Rank { get; set; }
         public int XP { get; set; }
 
+        public bool IsEmailPublic { get; set; } = false;
+
         [InverseProperty(nameof(Friend.User))]
         public ICollection<Friend>? Friends { get; set; }
         public ICollection<Like>? Likes { get; set; }

--- a/GameSite/Views/Shared/_Layout.cshtml
+++ b/GameSite/Views/Shared/_Layout.cshtml
@@ -26,9 +26,6 @@
                             <a class="nav-link text-dark" asp-controller="Feed" asp-action="Index">Feed</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-controller="Friends" asp-action="Index">Friends</a>
-                        </li>
-                        <li class="nav-item">
                             <a class="nav-link text-dark" asp-controller="Chat" asp-action="Index">Chat</a>
                         </li>
                         <li class="nav-item">

--- a/GameSite/Views/User/Index.cshtml
+++ b/GameSite/Views/User/Index.cshtml
@@ -23,21 +23,33 @@
         <span class="status-dot @color"></span>
     </p>
     <p>Your ID: @Model.User.UniqueId</p>
-    <p>Email: @Model.User.Email</p>
+    <p>
+        Email:
+        @if (Model.IsSelf || Model.User.IsEmailPublic)
+        {
+            @Model.User.Email
+        }
+        else
+        {
+            <span>Hidden</span>
+        }
+    </p>
     <p>Balance: @Model.User.Balance.ToString("0") GameCoins</p>
     <p>XP: @Model.User.XP</p>
     <p>Rank: @Model.User.Rank</p>
     @if (Model.IsSelf)
     {
-        <form asp-action="UpdateStatus" method="post" class="mb-2">
-            <select name="status" class="form-select d-inline w-auto">
-                <option value="@GameSite.Models.UserStatus.Online" selected="@(Model.User.Status == GameSite.Models.UserStatus.Online)">Online</option>
-                <option value="@GameSite.Models.UserStatus.DoNotDisturb" selected="@(Model.User.Status == GameSite.Models.UserStatus.DoNotDisturb)">Do Not Disturb</option>
-                <option value="@GameSite.Models.UserStatus.Offline" selected="@(Model.User.Status == GameSite.Models.UserStatus.Offline)">Offline</option>
-            </select>
-            <button type="submit" class="btn btn-sm btn-secondary ms-1">Set</button>
+        <select id="status-select" class="form-select d-inline w-auto">
+            <option value="@GameSite.Models.UserStatus.Online" selected="@(Model.User.Status == GameSite.Models.UserStatus.Online)">Online</option>
+            <option value="@GameSite.Models.UserStatus.DoNotDisturb" selected="@(Model.User.Status == GameSite.Models.UserStatus.DoNotDisturb)">Do Not Disturb</option>
+            <option value="@GameSite.Models.UserStatus.Offline" selected="@(Model.User.Status == GameSite.Models.UserStatus.Offline)">Offline</option>
+        </select>
+        <form asp-action="ToggleEmailVisibility" method="post" class="d-inline ms-2">
+            <input type="hidden" name="isPublic" value="@(Model.User.IsEmailPublic ? "false" : "true")" />
+            <button type="submit" class="btn btn-sm btn-secondary">@(Model.User.IsEmailPublic ? "Hide email" : "Show email")</button>
         </form>
-        <a asp-action="Edit" class="btn btn-primary">Edit profile</a>
+        <button type="button" class="btn btn-sm btn-primary ms-2" data-bs-toggle="modal" data-bs-target="#friendModal">Find friends</button>
+        <a asp-action="Edit" class="btn btn-primary ms-2">Edit profile</a>
     }
 }
 
@@ -72,3 +84,18 @@
     <h4 class="mt-4">Posts</h4>
     @await Html.PartialAsync("_PostList", Model.Posts)
 }
+
+<div class="modal fade" id="friendModal" tabindex="-1" aria-hidden="true">
+    <div class="modal-dialog">
+        <div class="modal-content">
+            <div class="modal-header">
+                <h5 class="modal-title">Find Friend</h5>
+                <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+            </div>
+            <div class="modal-body">
+                <input type="search" id="friend-search" class="form-control" placeholder="Enter user id" autocomplete="off" />
+                <div id="friend-search-results" class="list-group mt-2"></div>
+            </div>
+        </div>
+    </div>
+</div>

--- a/GameSite/wwwroot/js/site.js
+++ b/GameSite/wwwroot/js/site.js
@@ -113,4 +113,47 @@ document.addEventListener('DOMContentLoaded', () => {
             link.remove();
         });
     });
+
+    const statusSelect = document.getElementById('status-select');
+    if (statusSelect) {
+        statusSelect.addEventListener('change', async () => {
+            const val = statusSelect.value;
+            await fetch('/User/UpdateStatus', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'X-Requested-With': 'XMLHttpRequest' },
+                body: `status=${encodeURIComponent(val)}`
+            });
+        });
+    }
+
+    const friendSearch = document.getElementById('friend-search');
+    const friendResults = document.getElementById('friend-search-results');
+    if (friendSearch && friendResults) {
+        friendSearch.addEventListener('input', async () => {
+            const q = friendSearch.value.trim();
+            if (!q) { friendResults.innerHTML = ''; return; }
+            const res = await fetch(`/Search/Users?query=${encodeURIComponent(q)}`);
+            if (!res.ok) return;
+            const users = await res.json();
+            friendResults.innerHTML = '';
+            users.forEach(u => {
+                const div = document.createElement('div');
+                div.className = 'list-group-item d-flex justify-content-between align-items-center';
+                div.textContent = u.userName;
+                const btn = document.createElement('button');
+                btn.className = 'btn btn-sm btn-primary ms-2';
+                btn.textContent = 'Add';
+                btn.addEventListener('click', async () => {
+                    await fetch('/Friends/Add', {
+                        method: 'POST',
+                        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+                        body: `friendId=${encodeURIComponent(u.id)}`
+                    });
+                    window.location.reload();
+                });
+                div.appendChild(btn);
+                friendResults.appendChild(div);
+            });
+        });
+    }
 });


### PR DESCRIPTION
## Summary
- remove Friends tab from layout
- allow profile owners to toggle email visibility
- change status dropdown to auto-set on change
- move friend search to profile via a modal
- add Google login Razor page
- support new property `IsEmailPublic` with migration

## Testing
- `dotnet --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b10878f6483238a113601a83bb627