### PR TITLE
Add role display and text toggle

### DIFF
--- a/GameSite/Views/User/Index.cshtml
+++ b/GameSite/Views/User/Index.cshtml
@@ -23,6 +23,7 @@
         <span class="status-dot @color"></span>
     </p>
     <p>Your ID: @Model.User.UniqueId</p>
+    <p>Role: @Model.User.Role</p>
     <p>
         Email:
         @if (Model.IsSelf || Model.User.IsEmailPublic)

--- a/GameSite/wwwroot/js/site.js
+++ b/GameSite/wwwroot/js/site.js
@@ -108,9 +108,17 @@ document.addEventListener('DOMContentLoaded', () => {
         link.addEventListener('click', e => {
             e.preventDefault();
             const p = link.parentElement;
-            p.querySelector('.more-text').classList.remove('d-none');
-            p.querySelector('.ellipsis').classList.add('d-none');
-            link.remove();
+            const more = p.querySelector('.more-text');
+            const ellipsis = p.querySelector('.ellipsis');
+            if (more.classList.contains('d-none')) {
+                more.classList.remove('d-none');
+                ellipsis.classList.add('d-none');
+                link.textContent = '(скрыть..)';
+            } else {
+                more.classList.add('d-none');
+                ellipsis.classList.remove('d-none');
+                link.textContent = '(ещё..)';
+            }
         });
     });
 


### PR DESCRIPTION
## Summary
- show the user's role on the profile page
- allow toggling long post text between expand and collapse

## Testing
- `dotnet build GameSite/GameSite.csproj -nologo` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b132536648323b3783fb6202862cc