### PR TITLE
Update status dropdown and indicator

### DIFF
--- a/GameSite/Controllers/UserController.cs
+++ b/GameSite/Controllers/UserController.cs
@@ -237,5 +237,16 @@ namespace GameSite.Controllers
 
             return RedirectToAction(nameof(Index));
         }
+
+        [HttpGet]
+        public async Task<IActionResult> StatusIndicator()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null)
+            {
+                return NotFound();
+            }
+            return PartialView("_StatusIndicator", user.Status);
+        }
     }
 }

--- a/GameSite/Views/Shared/_StatusIndicator.cshtml
+++ b/GameSite/Views/Shared/_StatusIndicator.cshtml
@@ -1,0 +1,10 @@
+@model GameSite.Models.UserStatus
+@{
+    var color = Model switch
+    {
+        GameSite.Models.UserStatus.Online => "status-online",
+        GameSite.Models.UserStatus.DoNotDisturb => "status-dnd",
+        _ => "status-offline"
+    };
+}
+<span class="status-dot @color"></span>

--- a/GameSite/Views/User/Index.cshtml
+++ b/GameSite/Views/User/Index.cshtml
@@ -12,15 +12,9 @@
     }
     <p>
         UserName: @Model.User.UserName
-        @{
-            var color = Model.User.Status switch
-            {
-                GameSite.Models.UserStatus.Online => "status-online",
-                GameSite.Models.UserStatus.DoNotDisturb => "status-dnd",
-                _ => "status-offline"
-            };
-        }
-        <span class="status-dot @color"></span>
+        <span id="status-indicator">
+            @await Html.PartialAsync("_StatusIndicator", Model.User.Status)
+        </span>
     </p>
     <p>Your ID: @Model.User.UniqueId</p>
     <p>Role: @Model.User.Role</p>
@@ -43,7 +37,6 @@
         <select id="status-select" class="form-select d-inline w-auto">
             <option value="@GameSite.Models.UserStatus.Online" selected="@(Model.User.Status == GameSite.Models.UserStatus.Online)">Online</option>
             <option value="@GameSite.Models.UserStatus.DoNotDisturb" selected="@(Model.User.Status == GameSite.Models.UserStatus.DoNotDisturb)">Do Not Disturb</option>
-            <option value="@GameSite.Models.UserStatus.Offline" selected="@(Model.User.Status == GameSite.Models.UserStatus.Offline)">Offline</option>
         </select>
         <form asp-action="ToggleEmailVisibility" method="post" class="d-inline ms-2">
             <input type="hidden" name="isPublic" value="@(Model.User.IsEmailPublic ? "false" : "true")" />

--- a/GameSite/wwwroot/js/site.js
+++ b/GameSite/wwwroot/js/site.js
@@ -123,6 +123,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 
     const statusSelect = document.getElementById('status-select');
+    const statusIndicator = document.getElementById('status-indicator');
     if (statusSelect) {
         statusSelect.addEventListener('change', async () => {
             const val = statusSelect.value;
@@ -131,6 +132,12 @@ document.addEventListener('DOMContentLoaded', () => {
                 headers: { 'Content-Type': 'application/x-www-form-urlencoded', 'X-Requested-With': 'XMLHttpRequest' },
                 body: `status=${encodeURIComponent(val)}`
             });
+            if (statusIndicator) {
+                const res = await fetch('/User/StatusIndicator');
+                if (res.ok) {
+                    statusIndicator.innerHTML = await res.text();
+                }
+            }
         });
     }
 


### PR DESCRIPTION
## Summary
- remove `Offline` from profile status dropdown
- add reusable `_StatusIndicator` partial
- fetch the partial after status changes to update the indicator

## Testing
- `dotnet build GameSite/GameSite.csproj -c Release` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b186cde78832399913f5834287b56