### PR TITLE
Improve admin page and access control

### DIFF
--- a/GameSite/Controllers/AdminController.cs
+++ b/GameSite/Controllers/AdminController.cs
@@ -6,7 +6,7 @@ using GameSite.Models;
 
 namespace GameSite.Controllers
 {
-    [Authorize(Roles = "Admin")]
+    [Authorize(Roles = "Admin,Operator")]
     public class AdminController : Controller
     {
         private readonly UserManager<ApplicationUser> _userManager;
@@ -18,9 +18,18 @@ namespace GameSite.Controllers
             _roleManager = roleManager;
         }
 
-        public async Task<IActionResult> Index()
+        public async Task<IActionResult> Index(string? query)
         {
-            var users = await _userManager.Users.ToListAsync();
+            var q = _userManager.Users.AsQueryable();
+            if (!string.IsNullOrWhiteSpace(query))
+            {
+                query = query.Trim();
+                q = q.Where(u => u.Id.Contains(query) ||
+                                 (u.UserName != null && u.UserName.Contains(query)) ||
+                                 (u.Email != null && u.Email.Contains(query)));
+            }
+
+            var users = await q.ToListAsync();
             return View(users);
         }
     }

--- a/GameSite/Views/Admin/Index.cshtml
+++ b/GameSite/Views/Admin/Index.cshtml
@@ -4,16 +4,25 @@
 }
 
 <h2>Users</h2>
+
+<form method="get" class="mb-3">
+    <input type="text" name="query" class="form-control" placeholder="Search by id, username or email" value="@Context.Request.Query["query"]" />
+</form>
+
 <table class="table">
     <tr>
         <th>UserName</th>
         <th>Email</th>
+        <th>Rank</th>
+        <th>Balance</th>
     </tr>
 @foreach (var user in Model)
 {
     <tr>
-        <td>@user.UserName</td>
+        <td><a asp-controller="User" asp-action="Details" asp-route-id="@user.Id">@user.UserName</a></td>
         <td>@user.Email</td>
+        <td>@user.Rank</td>
+        <td>@user.Balance.ToString("0")</td>
     </tr>
 }
 </table>

--- a/GameSite/Views/Shared/_Layout.cshtml
+++ b/GameSite/Views/Shared/_Layout.cshtml
@@ -34,9 +34,12 @@
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-controller="User" asp-action="Index">Profile</a>
                         </li>
-                        <li class="nav-item">
-                            <a class="nav-link text-dark" asp-controller="Admin" asp-action="Index">Admin</a>
-                        </li>
+                        @if (User.IsInRole("Admin") || User.IsInRole("Operator"))
+                        {
+                            <li class="nav-item">
+                                <a class="nav-link text-dark" asp-controller="Admin" asp-action="Index">Admin</a>
+                            </li>
+                        }
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-area="" asp-controller="Home" asp-action="Privacy">Privacy</a>
                         </li>


### PR DESCRIPTION
## Summary
- restrict Admin button visibility to Admins and Operators only
- allow AdminController to be accessed by Admins and Operators
- support search on Admin user list page
- show user rank and balance with links to profile

## Testing
- `dotnet test` *(fails: no tests)*

------
https://chatgpt.com/codex/tasks/task_e_685b1b1236f88323be42975ba18fc734