### PR TITLE
Add dice game and modal menu

### DIFF
--- a/GameSite/Controllers/GameController.cs
+++ b/GameSite/Controllers/GameController.cs
@@ -24,6 +24,12 @@ namespace GameSite.Controllers
             return View(user);
         }
 
+        public async Task<IActionResult> Dice()
+        {
+            var user = await _userManager.GetUserAsync(User);
+            return View(user);
+        }
+
         [HttpPost]
         public async Task<IActionResult> AddXp(int amount)
         {

--- a/GameSite/Views/Game/Dice.cshtml
+++ b/GameSite/Views/Game/Dice.cshtml
@@ -1,0 +1,28 @@
+@model GameSite.Models.ApplicationUser
+@{
+    ViewData["Title"] = "Dice";
+}
+
+<h2>Dice</h2>
+<p>Your XP: @Model?.XP</p>
+
+<div class="mb-3">
+    <label class="form-label">Choose your number:</label>
+    <div id="dice-choice" class="btn-group" role="group">
+@for (int i = 1; i <= 6; i++)
+{
+        <input type="radio" class="btn-check" name="guess" id="guess@i" value="@i" autocomplete="off">
+        <label class="btn btn-outline-primary" for="guess@i">@i</label>
+}
+    </div>
+</div>
+<button id="roll-btn" class="btn btn-primary mb-3">Roll</button>
+<p id="dice-message" class="mt-2"></p>
+<div id="dice-container">
+    <canvas id="dice-canvas"></canvas>
+</div>
+
+@section Scripts {
+    <script src="https://cdn.jsdelivr.net/npm/three@0.164/build/three.min.js"></script>
+    <script src="~/js/dice.js" asp-append-version="true"></script>
+}

--- a/GameSite/Views/Shared/_Layout.cshtml
+++ b/GameSite/Views/Shared/_Layout.cshtml
@@ -29,7 +29,7 @@
                             <a class="nav-link text-dark" asp-controller="Chat" asp-action="Index">Chat</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" asp-controller="Game" asp-action="Index">Game</a>
+                            <a class="nav-link text-dark" href="#" data-bs-toggle="modal" data-bs-target="#gamesModal">Games</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link text-dark" asp-controller="User" asp-action="Index">Profile</a>
@@ -70,6 +70,27 @@
         <main role="main" class="pb-3">
             @RenderBody()
         </main>
+    </div>
+
+    <div class="modal fade" id="gamesModal" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title">Games</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <ul class="list-group">
+                        <li class="list-group-item">
+                            <a asp-controller="Game" asp-action="Index" class="text-decoration-none">Cube Game</a>
+                        </li>
+                        <li class="list-group-item">
+                            <a asp-controller="Game" asp-action="Dice" class="text-decoration-none">Dice</a>
+                        </li>
+                    </ul>
+                </div>
+            </div>
+        </div>
     </div>
 
     <footer class="border-top footer text-muted">

--- a/GameSite/wwwroot/css/site.css
+++ b/GameSite/wwwroot/css/site.css
@@ -100,3 +100,14 @@ body {
   height: 100%;
   display: block;
 }
+
+#dice-container {
+  width: 100%;
+  height: 300px;
+}
+
+#dice-canvas {
+  width: 100%;
+  height: 100%;
+  display: block;
+}

--- a/GameSite/wwwroot/js/dice.js
+++ b/GameSite/wwwroot/js/dice.js
@@ -1,0 +1,68 @@
+document.addEventListener('DOMContentLoaded', function () {
+    const container = document.getElementById('dice-container');
+    const canvas = document.getElementById('dice-canvas');
+    if (!container || !canvas || typeof THREE === 'undefined') return;
+
+    const width = container.clientWidth;
+    const height = container.clientHeight;
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(75, width / height, 0.1, 1000);
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: true });
+    renderer.setSize(width, height);
+
+    function createFaceTexture(num) {
+        const size = 128;
+        const c = document.createElement('canvas');
+        c.width = size;
+        c.height = size;
+        const ctx = c.getContext('2d');
+        ctx.fillStyle = '#ffffff';
+        ctx.fillRect(0, 0, size, size);
+        ctx.fillStyle = '#000000';
+        ctx.font = 'bold 64px sans-serif';
+        ctx.textAlign = 'center';
+        ctx.textBaseline = 'middle';
+        ctx.fillText(num.toString(), size / 2, size / 2);
+        return new THREE.CanvasTexture(c);
+    }
+
+    const materials = [];
+    for (let i = 1; i <= 6; i++) {
+        materials.push(new THREE.MeshBasicMaterial({ map: createFaceTexture(i) }));
+    }
+
+    const geometry = new THREE.BoxGeometry();
+    const cube = new THREE.Mesh(geometry, materials);
+    scene.add(cube);
+    camera.position.z = 2;
+
+    function animate() {
+        requestAnimationFrame(animate);
+        renderer.render(scene, camera);
+    }
+    animate();
+
+    document.getElementById('roll-btn')?.addEventListener('click', () => {
+        const guessEl = document.querySelector('input[name="guess"]:checked');
+        const message = document.getElementById('dice-message');
+        if (!guessEl) {
+            if (message) message.textContent = 'Choose a number first';
+            return;
+        }
+        const result = Math.floor(Math.random() * 6) + 1;
+        const rotations = {
+            1: [0, 0, 0],
+            2: [0, Math.PI / 2, 0],
+            3: [0, Math.PI, 0],
+            4: [0, -Math.PI / 2, 0],
+            5: [-Math.PI / 2, 0, 0],
+            6: [Math.PI / 2, 0, 0]
+        };
+        const [rx, ry, rz] = rotations[result];
+        cube.rotation.set(rx, ry, rz);
+        if (message) {
+            message.textContent = result == guessEl.value ? 'You guessed right! +10 XP' : `You rolled ${result}`;
+        }
+    });
+});


### PR DESCRIPTION
## Summary
- add Dice game view and three.js dice script
- extend GameController with `Dice` action
- convert Game nav link to Games modal with links to Cube Game and Dice
- style dice WebGL canvas

## Testing
- `dotnet build GameSite/GameSite.csproj -v q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1ca552c48323afbc10e5dcd137b6