### PR TITLE
Add leaderboard tables on home page

### DIFF
--- a/GameSite/Controllers/HomeController.cs
+++ b/GameSite/Controllers/HomeController.cs
@@ -1,21 +1,40 @@
 using System.Diagnostics;
+using GameSite.Data;
 using GameSite.Models;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
 
 namespace GameSite.Controllers
 {
     public class HomeController : Controller
     {
         private readonly ILogger<HomeController> _logger;
+        private readonly ApplicationDbContext _context;
 
-        public HomeController(ILogger<HomeController> logger)
+        public HomeController(ILogger<HomeController> logger, ApplicationDbContext context)
         {
             _logger = logger;
+            _context = context;
         }
 
-        public IActionResult Index()
+        public async Task<IActionResult> Index()
         {
-            return View();
+            var model = new LeaderboardViewModel
+            {
+                TopXP = await _context.Users
+                    .OrderByDescending(u => u.XP)
+                    .Take(10)
+                    .ToListAsync(),
+                TopRank = await _context.Users
+                    .OrderByDescending(u => u.Rank)
+                    .Take(10)
+                    .ToListAsync(),
+                TopBalance = await _context.Users
+                    .OrderByDescending(u => u.Balance)
+                    .Take(10)
+                    .ToListAsync()
+            };
+            return View(model);
         }
 
         public IActionResult Privacy()

--- a/GameSite/Models/LeaderboardViewModel.cs
+++ b/GameSite/Models/LeaderboardViewModel.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace GameSite.Models
+{
+    public class LeaderboardViewModel
+    {
+        public List<ApplicationUser> TopXP { get; set; } = new();
+        public List<ApplicationUser> TopRank { get; set; } = new();
+        public List<ApplicationUser> TopBalance { get; set; } = new();
+    }
+}

--- a/GameSite/Views/Home/Index.cshtml
+++ b/GameSite/Views/Home/Index.cshtml
@@ -1,8 +1,54 @@
-﻿@{
+@model GameSite.Models.LeaderboardViewModel
+@{
     ViewData["Title"] = "Home Page";
 }
 
 <div class="text-center">
     <h1 class="display-4">Welcome</h1>
     <p>Learn about <a href="https://learn.microsoft.com/aspnet/core">building Web apps with ASP.NET Core</a>.</p>
+</div>
+
+<div class="row mt-4">
+    <div class="col-md-4">
+        <h4>XP Leaders</h4>
+        <table class="table table-sm">
+            <thead>
+                <tr><th>UserName</th><th>XP</th></tr>
+            </thead>
+            <tbody>
+            @foreach (var u in Model.TopXP)
+            {
+                <tr><td>@u.UserName</td><td>@u.XP</td></tr>
+            }
+            </tbody>
+        </table>
+    </div>
+    <div class="col-md-4">
+        <h4>Rank Leaders</h4>
+        <table class="table table-sm">
+            <thead>
+                <tr><th>UserName</th><th>Rank</th></tr>
+            </thead>
+            <tbody>
+            @foreach (var u in Model.TopRank)
+            {
+                <tr><td>@u.UserName</td><td>@u.Rank</td></tr>
+            }
+            </tbody>
+        </table>
+    </div>
+    <div class="col-md-4">
+        <h4>Balance Leaders</h4>
+        <table class="table table-sm">
+            <thead>
+                <tr><th>UserName</th><th>Balance</th></tr>
+            </thead>
+            <tbody>
+            @foreach (var u in Model.TopBalance)
+            {
+                <tr><td>@u.UserName</td><td>@u.Balance.ToString("0")</td></tr>
+            }
+            </tbody>
+        </table>
+    </div>
 </div>


### PR DESCRIPTION
## Summary
- collect top users by XP, rank and balance in `HomeController`
- store leaderboard data in new `LeaderboardViewModel`
- show three leaderboards on the home page

## Testing
- `dotnet test` *(fails: `dotnet` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b1e0a59488323bbb5e2a3ae6807b3