### PR TITLE
Implement chat page and messaging

### DIFF
--- a/GameSite/Controllers/ChatController.cs
+++ b/GameSite/Controllers/ChatController.cs
@@ -55,13 +55,65 @@ namespace GameSite.Controllers
                 return NotFound();
             }
 
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null)
+            {
+                return NotFound();
+            }
+
             var friend = await _userManager.FindByIdAsync(friendId);
             if (friend == null)
             {
                 return NotFound();
             }
 
-            return PartialView("_ChatWindow", friend);
+            var messages = await _context.ChatMessages
+                .Where(m => (m.SenderId == user.Id && m.RecipientId == friendId) ||
+                            (m.SenderId == friendId && m.RecipientId == user.Id))
+                .OrderBy(m => m.Created)
+                .ToListAsync();
+
+            var vm = new ChatWindowViewModel
+            {
+                Friend = friend,
+                Messages = messages
+            };
+
+            return PartialView("_ChatWindow", vm);
+        }
+
+        [HttpPost]
+        public async Task<IActionResult> Send(string friendId, string message, IFormFile? image)
+        {
+            if (string.IsNullOrWhiteSpace(friendId)) return BadRequest();
+            var user = await _userManager.GetUserAsync(User);
+            if (user == null) return Unauthorized();
+
+            var msg = new ChatMessage
+            {
+                SenderId = user.Id,
+                RecipientId = friendId,
+                Content = message ?? string.Empty,
+                Created = DateTime.UtcNow
+            };
+
+            if (image != null && image.Length > 0)
+            {
+                var uploads = Path.Combine("wwwroot", "uploads");
+                Directory.CreateDirectory(uploads);
+                var fileName = Guid.NewGuid().ToString() + Path.GetExtension(image.FileName);
+                var filePath = Path.Combine(uploads, fileName);
+                using (var stream = System.IO.File.Create(filePath))
+                {
+                    await image.CopyToAsync(stream);
+                }
+                msg.MediaPath = "/uploads/" + fileName;
+            }
+
+            _context.ChatMessages.Add(msg);
+            await _context.SaveChangesAsync();
+
+            return RedirectToAction(nameof(Window), new { friendId });
         }
     }
 }

--- a/GameSite/Data/ApplicationDbContext.cs
+++ b/GameSite/Data/ApplicationDbContext.cs
@@ -14,6 +14,7 @@ namespace GameSite.Data
         public DbSet<Friend> Friends => Set<Friend>();
         public DbSet<Like> Likes => Set<Like>();
         public DbSet<Post> Posts => Set<Post>();
+        public DbSet<ChatMessage> ChatMessages => Set<ChatMessage>();
 
         protected override void OnModelCreating(ModelBuilder builder)
         {

--- a/GameSite/Data/Migrations/20250624222818_ChatMessages.Designer.cs
+++ b/GameSite/Data/Migrations/20250624222818_ChatMessages.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using GameSite.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace GameSite.Data.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250624222818_ChatMessages")]
+    partial class ChatMessages
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/GameSite/Data/Migrations/20250624222818_ChatMessages.cs
+++ b/GameSite/Data/Migrations/20250624222818_ChatMessages.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
+
+#nullable disable
+
+namespace GameSite.Data.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChatMessages : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ChatMessages",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "integer", nullable: false)
+                        .Annotation("Npgsql:ValueGenerationStrategy", NpgsqlValueGenerationStrategy.IdentityByDefaultColumn),
+                    SenderId = table.Column<string>(type: "text", nullable: false),
+                    RecipientId = table.Column<string>(type: "text", nullable: false),
+                    Content = table.Column<string>(type: "text", nullable: false),
+                    MediaPath = table.Column<string>(type: "text", nullable: true),
+                    Created = table.Column<DateTime>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ChatMessages", x => x.Id);
+                });
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ChatMessages");
+        }
+    }
+}

--- a/GameSite/Models/ChatMessage.cs
+++ b/GameSite/Models/ChatMessage.cs
@@ -1,0 +1,23 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace GameSite.Models
+{
+    public class ChatMessage
+    {
+        public int Id { get; set; }
+
+        [Required]
+        public string SenderId { get; set; } = null!;
+
+        [Required]
+        public string RecipientId { get; set; } = null!;
+
+        [Required]
+        public string Content { get; set; } = string.Empty;
+
+        public string? MediaPath { get; set; }
+
+        public DateTime Created { get; set; }
+    }
+}

--- a/GameSite/Models/ChatWindowViewModel.cs
+++ b/GameSite/Models/ChatWindowViewModel.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+
+namespace GameSite.Models
+{
+    public class ChatWindowViewModel
+    {
+        public ApplicationUser Friend { get; set; } = null!;
+        public List<ChatMessage> Messages { get; set; } = new();
+    }
+}

--- a/GameSite/Views/Chat/Index.cshtml
+++ b/GameSite/Views/Chat/Index.cshtml
@@ -3,6 +3,4 @@
     ViewData["Title"] = "Chat";
 }
 
-<div style="height:500px;">
-    @await Html.PartialAsync("_Chat", Model)
-</div>
+@await Html.PartialAsync("_Chat", Model)

--- a/GameSite/Views/Chat/_ChatWindow.cshtml
+++ b/GameSite/Views/Chat/_ChatWindow.cshtml
@@ -1,8 +1,24 @@
-@model GameSite.Models.ApplicationUser
+@model GameSite.Models.ChatWindowViewModel
 <div>
-    <h5 class="border-bottom pb-2 mb-2">Chat with @Model.UserName</h5>
+    <h5 class="border-bottom pb-2 mb-2">Chat with @Model.Friend.UserName</h5>
     <div id="messages" class="border mb-2 p-2" style="height:250px; overflow-y:auto;">
-        <p class="text-muted">Chat not implemented.</p>
+        @foreach (var m in Model.Messages)
+        {
+            <div class="mb-1">
+                <strong>@(m.SenderId == User.FindFirst("sub")?.Value ? "You" : Model.Friend.UserName)</strong>:
+                @m.Content
+                @if (!string.IsNullOrEmpty(m.MediaPath))
+                {
+                    <div><img src="@m.MediaPath" class="img-fluid mt-1" /></div>
+                }
+            </div>
+        }
     </div>
-    <input type="text" class="form-control" placeholder="Type a message..." disabled />
+    <form asp-controller="Chat" asp-action="Send" asp-route-friendId="@Model.Friend.Id" enctype="multipart/form-data">
+        <div class="input-group">
+            <input type="text" name="message" class="form-control" placeholder="Type a message..." />
+            <input type="file" name="image" class="form-control" />
+            <button type="submit" class="btn btn-primary">Send</button>
+        </div>
+    </form>
 </div>

--- a/GameSite/Views/Shared/_Layout.cshtml
+++ b/GameSite/Views/Shared/_Layout.cshtml
@@ -26,7 +26,7 @@
                             <a class="nav-link text-dark" asp-controller="Feed" asp-action="Index">Feed</a>
                         </li>
                         <li class="nav-item">
-                            <a class="nav-link text-dark" href="#" id="chat-link">Chat</a>
+                            <a class="nav-link text-dark" asp-controller="Chat" asp-action="Index">Chat</a>
                         </li>
                         <li class="nav-item">
                             <a class="nav-link text-dark" href="#" data-bs-toggle="modal" data-bs-target="#gamesModal">Games</a>
@@ -72,7 +72,6 @@
         </main>
     </div>
 
-    <div id="chat-container" class="border position-fixed bg-white shadow" style="bottom:0; right:0; width:600px; height:400px; display:none; z-index:1050; overflow:hidden;"></div>
 
     <div class="modal fade" id="gamesModal" tabindex="-1" aria-hidden="true">
         <div class="modal-dialog">

--- a/GameSite/wwwroot/js/site.js
+++ b/GameSite/wwwroot/js/site.js
@@ -172,24 +172,7 @@ document.addEventListener('DOMContentLoaded', () => {
     });
 }
 
-    const chatLink = document.getElementById('chat-link');
-    const chatContainer = document.getElementById('chat-container');
-    if (chatLink && chatContainer) {
-        chatLink.addEventListener('click', async e => {
-            e.preventDefault();
-            if (chatContainer.style.display === 'none' || chatContainer.style.display === '') {
-                if (chatContainer.innerHTML.trim() === '') {
-                    const res = await fetch('/Chat/Panel');
-                    if (res.ok) {
-                        chatContainer.innerHTML = await res.text();
-                    }
-                }
-                chatContainer.style.display = 'block';
-            } else {
-                chatContainer.style.display = 'none';
-            }
-        });
-    }
+
 
     document.addEventListener('click', async e => {
         if (e.target.classList.contains('chat-friend-link')) {


### PR DESCRIPTION
## Summary
- support persistent chat messages
- show chat conversation page with message form and image upload
- add ChatMessages table via EF Core migration
- remove old chat modal logic and link directly to chat page

## Testing
- `dotnet build`
- `dotnet ef database update` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_685b25c1205083239142daf8d6db8a57