### PR TITLE
Add password reset and improve chat

### DIFF
--- a/GameSite/Areas/Identity/Pages/Account/ForgotPassword.cshtml
+++ b/GameSite/Areas/Identity/Pages/Account/ForgotPassword.cshtml
@@ -1,0 +1,17 @@
+@page
+@model GameSite.Areas.Identity.Pages.Account.ForgotPasswordModel
+@{
+    ViewData["Title"] = "Forgot password";
+}
+<h1>@ViewData["Title"]</h1>
+<form method="post">
+    <div class="mb-3">
+        <label asp-for="Input.Email" class="form-label"></label>
+        <input asp-for="Input.Email" class="form-control" />
+        <span asp-validation-for="Input.Email" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Send reset link</button>
+</form>
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/GameSite/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
+++ b/GameSite/Areas/Identity/Pages/Account/ForgotPassword.cshtml.cs
@@ -1,0 +1,53 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity.UI.Services;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using GameSite.Models;
+
+namespace GameSite.Areas.Identity.Pages.Account
+{
+    public class ForgotPasswordModel : PageModel
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+        private readonly IEmailSender _emailSender;
+
+        public ForgotPasswordModel(UserManager<ApplicationUser> userManager, IEmailSender emailSender)
+        {
+            _userManager = userManager;
+            _emailSender = emailSender;
+        }
+
+        [BindProperty]
+        public InputModel Input { get; set; } = new();
+
+        public class InputModel
+        {
+            [Required]
+            [EmailAddress]
+            public string Email { get; set; } = string.Empty;
+        }
+
+        public void OnGet()
+        {
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            var user = await _userManager.FindByEmailAsync(Input.Email);
+            if (user != null)
+            {
+                var token = await _userManager.GeneratePasswordResetTokenAsync(user);
+                var callbackUrl = Url.Page("/Account/ResetPassword", null, new { area = "Identity", userId = user.Id, token }, Request.Scheme);
+                await _emailSender.SendEmailAsync(Input.Email, "Reset Password", $"<a href=\"{callbackUrl}\">Reset Password</a>");
+            }
+
+            return RedirectToPage("Login");
+        }
+    }
+}

--- a/GameSite/Areas/Identity/Pages/Account/Login.cshtml
+++ b/GameSite/Areas/Identity/Pages/Account/Login.cshtml
@@ -26,6 +26,10 @@
     {
         <a asp-controller="Account" asp-action="GoogleLogin" class="btn btn-danger ms-2">Google</a>
     }
+    <div class="mt-2">
+        <a asp-page="./Register">Register</a> |
+        <a asp-page="./ForgotPassword">Forgot password?</a>
+    </div>
 </form>
 
 @section Scripts {

--- a/GameSite/Areas/Identity/Pages/Account/ResetPassword.cshtml
+++ b/GameSite/Areas/Identity/Pages/Account/ResetPassword.cshtml
@@ -1,0 +1,24 @@
+@page
+@model GameSite.Areas.Identity.Pages.Account.ResetPasswordModel
+@{
+    ViewData["Title"] = "Reset password";
+}
+<h1>@ViewData["Title"]</h1>
+<form method="post">
+    <input type="hidden" asp-for="UserId" />
+    <input type="hidden" asp-for="Token" />
+    <div class="mb-3">
+        <label asp-for="Input.Password" class="form-label"></label>
+        <input asp-for="Input.Password" class="form-control" />
+        <span asp-validation-for="Input.Password" class="text-danger"></span>
+    </div>
+    <div class="mb-3">
+        <label asp-for="Input.ConfirmPassword" class="form-label"></label>
+        <input asp-for="Input.ConfirmPassword" class="form-control" />
+        <span asp-validation-for="Input.ConfirmPassword" class="text-danger"></span>
+    </div>
+    <button type="submit" class="btn btn-primary">Reset Password</button>
+</form>
+@section Scripts {
+    <partial name="_ValidationScriptsPartial" />
+}

--- a/GameSite/Areas/Identity/Pages/Account/ResetPassword.cshtml.cs
+++ b/GameSite/Areas/Identity/Pages/Account/ResetPassword.cshtml.cs
@@ -1,0 +1,71 @@
+using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.RazorPages;
+using GameSite.Models;
+
+namespace GameSite.Areas.Identity.Pages.Account
+{
+    public class ResetPasswordModel : PageModel
+    {
+        private readonly UserManager<ApplicationUser> _userManager;
+
+        public ResetPasswordModel(UserManager<ApplicationUser> userManager)
+        {
+            _userManager = userManager;
+        }
+
+        [BindProperty]
+        public InputModel Input { get; set; } = new();
+
+        [BindProperty(SupportsGet = true)]
+        public string Token { get; set; } = string.Empty;
+
+        [BindProperty(SupportsGet = true)]
+        public string UserId { get; set; } = string.Empty;
+
+        public class InputModel
+        {
+            [Required]
+            [StringLength(100, MinimumLength = 4)]
+            [DataType(DataType.Password)]
+            public string Password { get; set; } = string.Empty;
+
+            [DataType(DataType.Password)]
+            [Display(Name = "Confirm password")]
+            [Compare("Password")]
+            public string ConfirmPassword { get; set; } = string.Empty;
+        }
+
+        public void OnGet()
+        {
+        }
+
+        public async Task<IActionResult> OnPostAsync()
+        {
+            if (!ModelState.IsValid)
+            {
+                return Page();
+            }
+
+            var user = await _userManager.FindByIdAsync(UserId);
+            if (user == null)
+            {
+                return RedirectToPage("Login");
+            }
+
+            var result = await _userManager.ResetPasswordAsync(user, Token, Input.Password);
+            if (result.Succeeded)
+            {
+                return RedirectToPage("Login");
+            }
+
+            foreach (var error in result.Errors)
+            {
+                ModelState.AddModelError(string.Empty, error.Description);
+            }
+
+            return Page();
+        }
+    }
+}

--- a/GameSite/Controllers/ChatController.cs
+++ b/GameSite/Controllers/ChatController.cs
@@ -122,6 +122,7 @@ namespace GameSite.Controllers
                 senderName = user.UserName,
                 content = msg.Content,
                 mediaPath = msg.MediaPath,
+                created = msg.Created,
                 isOwn = false
             });
 
@@ -131,6 +132,7 @@ namespace GameSite.Controllers
                 senderName = user.UserName,
                 content = msg.Content,
                 mediaPath = msg.MediaPath,
+                created = msg.Created,
                 isOwn = true
             });
 

--- a/GameSite/Program.cs
+++ b/GameSite/Program.cs
@@ -37,7 +37,6 @@ namespace GameSite
             builder.Services.AddTransient<IPasswordValidator<ApplicationUser>, CustomPasswordValidator>();
             builder.Services.Configure<EmailSettings>(builder.Configuration.GetSection("EmailSettings"));
             builder.Services.AddTransient<IEmailSender, EmailSender>();
-            builder.Services.AddTransient<IEmailService, EmailSender>();
             builder.Services.AddTransient<IGoogleAuthService, GoogleAuthService>();
             var authenticationBuilder = builder.Services.AddAuthentication();
             var googleAuth = builder.Configuration.GetSection("Authentication:Google");

--- a/GameSite/Services/EmailSender.cs
+++ b/GameSite/Services/EmailSender.cs
@@ -7,7 +7,7 @@ using GameSite.Models;
 
 namespace GameSite.Services
 {
-    public class EmailSender : IEmailSender, IEmailService
+    public class EmailSender : IEmailSender
     {
         private readonly EmailSettings _settings;
 

--- a/GameSite/Services/IAuthService.cs
+++ b/GameSite/Services/IAuthService.cs
@@ -1,6 +1,0 @@
-namespace GameSite.Services
-{
-    public interface IAuthService
-    {
-    }
-}

--- a/GameSite/Services/IChatService.cs
+++ b/GameSite/Services/IChatService.cs
@@ -1,6 +1,0 @@
-namespace GameSite.Services
-{
-    public interface IChatService
-    {
-    }
-}

--- a/GameSite/Services/IEmailService.cs
+++ b/GameSite/Services/IEmailService.cs
@@ -1,8 +1,0 @@
-using System.Threading.Tasks;
-namespace GameSite.Services
-{
-    public interface IEmailService
-    {
-        Task SendEmailAsync(string email, string subject, string htmlMessage);
-    }
-}

--- a/GameSite/Services/IFriendService.cs
+++ b/GameSite/Services/IFriendService.cs
@@ -1,6 +1,0 @@
-namespace GameSite.Services
-{
-    public interface IFriendService
-    {
-    }
-}

--- a/GameSite/Services/IPostService.cs
+++ b/GameSite/Services/IPostService.cs
@@ -1,6 +1,0 @@
-namespace GameSite.Services
-{
-    public interface IPostService
-    {
-    }
-}

--- a/GameSite/Services/IRoleService.cs
+++ b/GameSite/Services/IRoleService.cs
@@ -1,6 +1,0 @@
-namespace GameSite.Services
-{
-    public interface IRoleService
-    {
-    }
-}

--- a/GameSite/Services/IUserService.cs
+++ b/GameSite/Services/IUserService.cs
@@ -1,6 +1,0 @@
-namespace GameSite.Services
-{
-    public interface IUserService
-    {
-    }
-}

--- a/GameSite/Services/IXPService.cs
+++ b/GameSite/Services/IXPService.cs
@@ -1,6 +1,0 @@
-namespace GameSite.Services
-{
-    public interface IXPService
-    {
-    }
-}

--- a/GameSite/Views/Chat/_ChatWindow.cshtml
+++ b/GameSite/Views/Chat/_ChatWindow.cshtml
@@ -4,8 +4,9 @@
     <div id="messages" class="border mb-2 p-2" style="height:250px; overflow-y:auto;">
         @foreach (var m in Model.Messages)
         {
-            <div class="mb-1">
-                <strong>@(m.SenderId == User.FindFirst("sub")?.Value ? "You" : Model.Friend.UserName)</strong>:
+            var own = m.SenderId == User.FindFirst("sub")?.Value;
+            <div class="mb-1 @(own ? "text-end" : "text-start")">
+                <strong>@(own ? "You" : Model.Friend.UserName) @m.Created.ToLocalTime().ToString("HH:mm")</strong><br />
                 @m.Content
                 @if (!string.IsNullOrEmpty(m.MediaPath))
                 {

--- a/GameSite/wwwroot/js/chat.js
+++ b/GameSite/wwwroot/js/chat.js
@@ -6,11 +6,13 @@ connection.on('ReceiveMessage', msg => {
     const messagesDiv = document.getElementById('messages');
     if (!messagesDiv) return;
     const div = document.createElement('div');
-    div.className = 'mb-1';
+    div.className = 'mb-1 ' + (msg.isOwn ? 'text-end' : 'text-start');
     const strong = document.createElement('strong');
-    strong.textContent = msg.isOwn ? 'You' : msg.senderName;
+    const time = msg.created ? new Date(msg.created).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' }) : '';
+    strong.textContent = (msg.isOwn ? 'You' : msg.senderName) + ' ' + time;
     div.appendChild(strong);
-    div.append(document.createTextNode(': ' + msg.content));
+    div.append(document.createElement('br'));
+    div.append(document.createTextNode(msg.content));
     if (msg.mediaPath) {
         const img = document.createElement('img');
         img.src = msg.mediaPath;
@@ -27,6 +29,15 @@ function initChat() {
     const messageInput = document.getElementById('chat-message');
     if (messageInput && $(messageInput).emojioneArea) {
         $(messageInput).emojioneArea({ pickerPosition: 'top' });
+    }
+    if (messageInput) {
+        messageInput.addEventListener('keydown', e => {
+            if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                const form = document.getElementById('chat-form');
+                if (form) form.dispatchEvent(new Event('submit', { cancelable: true }));
+            }
+        });
     }
 }
 


### PR DESCRIPTION
## Summary
- add forgot/reset password Razor pages
- link registration and password reset from login page
- clean up unused service interfaces
- include timestamp and alignment in chat
- allow sending chat messages with Enter key

## Testing
- `dotnet restore`
- `dotnet build --no-restore`
- `dotnet test`

------
https://chatgpt.com/codex/tasks/task_e_685b3011ae848323841f32a597a9b69d