### PR TITLE
Improve chat UX with file attachments

### DIFF
--- a/GameSite/Views/Chat/_ChatWindow.cshtml
+++ b/GameSite/Views/Chat/_ChatWindow.cshtml
@@ -12,9 +12,17 @@
     </div>
     <form id="chat-form" asp-controller="Chat" asp-action="Send" asp-route-friendId="@Model.Friend.Id" data-friend-id="@Model.Friend.Id" enctype="multipart/form-data">
         <div class="input-group">
+            <div class="btn-group dropup">
+                <button class="btn btn-outline-secondary dropdown-toggle" type="button" id="attachDropdown" data-bs-toggle="dropdown" aria-expanded="false">📎</button>
+                <ul class="dropdown-menu" aria-labelledby="attachDropdown">
+                    <li><a class="dropdown-item attach-option" href="#" data-type="media">Фото или видео</a></li>
+                    <li><a class="dropdown-item attach-option" href="#" data-type="doc">Документ</a></li>
+                </ul>
+            </div>
             <input type="text" id="chat-message" name="message" class="form-control" placeholder="Type a message..." />
-            <input type="file" name="image" class="form-control" />
-            <button type="submit" class="btn btn-primary">Send</button>
+            <input type="file" id="chat-file" name="file" class="d-none" />
+            <button type="submit" id="send-btn" class="btn btn-primary" disabled>Send</button>
         </div>
+        <div id="selected-file" class="text-muted small mt-1"></div>
     </form>
 </div>

--- a/GameSite/Views/Chat/_Message.cshtml
+++ b/GameSite/Views/Chat/_Message.cshtml
@@ -9,6 +9,18 @@
     @Model.Content
     @if (!string.IsNullOrEmpty(Model.MediaPath))
     {
-        <div><img src="@Model.MediaPath" class="img-fluid mt-1" /></div>
+        var ext = System.IO.Path.GetExtension(Model.MediaPath).ToLowerInvariant();
+        if (ext == ".jpg" || ext == ".png")
+        {
+            <div><img src="@Model.MediaPath" class="img-fluid mt-1" /></div>
+        }
+        else if (ext == ".mp4" || ext == ".mov")
+        {
+            <div><video src="@Model.MediaPath" controls class="img-fluid mt-1"></video></div>
+        }
+        else
+        {
+            <div><a href="@Model.MediaPath" target="_blank">Download file</a></div>
+        }
     }
 </div>

--- a/GameSite/wwwroot/js/chat.js
+++ b/GameSite/wwwroot/js/chat.js
@@ -14,10 +14,27 @@ connection.on('ReceiveMessage', msg => {
     div.append(document.createElement('br'));
     div.append(document.createTextNode(msg.content));
     if (msg.mediaPath) {
-        const img = document.createElement('img');
-        img.src = msg.mediaPath;
-        img.className = 'img-fluid mt-1';
-        div.appendChild(document.createElement('div')).appendChild(img);
+        const ext = msg.mediaPath.split('.').pop().toLowerCase();
+        let container = document.createElement('div');
+        if (ext === 'jpg' || ext === 'png') {
+            const img = document.createElement('img');
+            img.src = msg.mediaPath;
+            img.className = 'img-fluid mt-1';
+            container.appendChild(img);
+        } else if (ext === 'mp4' || ext === 'mov') {
+            const video = document.createElement('video');
+            video.src = msg.mediaPath;
+            video.controls = true;
+            video.className = 'img-fluid mt-1';
+            container.appendChild(video);
+        } else {
+            const link = document.createElement('a');
+            link.href = msg.mediaPath;
+            link.target = '_blank';
+            link.textContent = 'Download file';
+            container.appendChild(link);
+        }
+        div.appendChild(container);
     }
     messagesDiv.appendChild(div);
     messagesDiv.scrollTop = messagesDiv.scrollHeight;
@@ -39,16 +56,48 @@ function initChat() {
             }
         });
     }
+    const fileInput = document.getElementById('chat-file');
     const form = document.getElementById('chat-form');
     if (form) {
         form.addEventListener('submit', sendChat);
     }
+    if (messageInput) {
+        const area = $(messageInput).data('emojioneArea');
+        if (area && area.editor) {
+            area.editor.on('input', updateSendState);
+        } else {
+            messageInput.addEventListener('input', updateSendState);
+        }
+    }
+    if (fileInput) {
+        fileInput.addEventListener('change', updateSendState);
+    }
+    document.querySelectorAll('.attach-option').forEach(opt => {
+        opt.addEventListener('click', e => {
+            e.preventDefault();
+            if (!fileInput) return;
+            const type = opt.dataset.type;
+            if (type === 'media') {
+                fileInput.accept = '.jpg,.png,.mp4,.mov';
+            } else {
+                fileInput.accept = '.pdf,.docx,.txt';
+            }
+            fileInput.value = '';
+            fileInput.click();
+        });
+    });
+    updateSendState();
 }
 
 async function sendChat(e) {
     e.preventDefault();
     const form = e.target;
     const friendId = form.dataset.friendId;
+    const fileInput = document.getElementById('chat-file');
+    if (fileInput && fileInput.files.length > 0 && fileInput.files[0].size > 1610612736) {
+        alert('File is too large');
+        return;
+    }
     const data = new FormData(form);
     const res = await fetch(`/Chat/Send?friendId=${encodeURIComponent(friendId)}`, {
         method: 'POST',
@@ -56,6 +105,38 @@ async function sendChat(e) {
     });
     if (res.ok) {
         form.reset();
+        clearMessageText();
+        updateSendState();
+    }
+}
+
+function getMessageText() {
+    const input = document.getElementById('chat-message');
+    if (input && $(input).data('emojioneArea')) {
+        return $(input).data('emojioneArea').getText();
+    }
+    return input ? input.value : '';
+}
+
+function clearMessageText() {
+    const input = document.getElementById('chat-message');
+    if (input && $(input).data('emojioneArea')) {
+        $(input).data('emojioneArea').setText('');
+    } else if (input) {
+        input.value = '';
+    }
+}
+
+function updateSendState() {
+    const btn = document.getElementById('send-btn');
+    const fileInput = document.getElementById('chat-file');
+    if (!btn || !fileInput) return;
+    const hasText = getMessageText().trim().length > 0;
+    const hasFile = fileInput.files.length > 0;
+    btn.disabled = !(hasText || hasFile);
+    const nameDiv = document.getElementById('selected-file');
+    if (nameDiv) {
+        nameDiv.textContent = hasFile ? fileInput.files[0].name : '';
     }
 }
 


### PR DESCRIPTION
## Summary
- fix duplicate message text by clearing Emoji text
- disable Send button on empty input
- add attachment dropdown to chat window
- validate uploaded file type and size
- display images, video and files in messages

## Testing
- `dotnet build GameSite/GameSite.csproj -clp:ErrorsOnly`

------
https://chatgpt.com/codex/tasks/task_e_685bba5c8c048323be3de147c0629036