### PR TITLE
Implement phase toggling and add rule tests

### DIFF
--- a/dist/durak.js
+++ b/dist/durak.js
@@ -6,7 +6,6 @@ exports.dealInitial = dealInitial;
 exports.canBeat = canBeat;
 exports.attack = attack;
 exports.defend = defend;
-
 const RANKS = [6, 7, 8, 9, 10, 11, 12, 13, 14];
 const SUITS = ['clubs', 'diamonds', 'hearts', 'spades'];
 function buildDeck(size = 36) {
@@ -51,10 +50,7 @@ function dealInitial() {
         });
     });
     const defender = attacker === 'human' ? 'ai' : 'human';
-    const rest = deck.slice(index);
-
     const rest = deck.slice(index, deck.length - 1);
-
     return {
         players,
         deck: rest,
@@ -65,7 +61,6 @@ function dealInitial() {
         phase: 'attack'
     };
 }
-
 function ranksOnTable(state) {
     const ranks = [];
     state.table.forEach(p => {
@@ -117,8 +112,11 @@ function defend(state, attackIndex, cardId) {
         return false;
     defender.hand.splice(idx, 1);
     pair.defense = card;
-    if (state.table.every(p => p.defense))
+    if (state.table.every(p => p.defense)) {
         state.phase = 'resolution';
+    }
+    else {
+        state.phase = 'attack';
+    }
     return true;
 }
-

--- a/src/durak.ts
+++ b/src/durak.ts
@@ -46,9 +46,7 @@ export function dealInitial(): GameState {
   });
   const defender = attacker === 'human' ? 'ai' : 'human';
 
-  const rest = deck.slice(index);
-
-  const rest = deck.slice(index, deck.length-1);
+  const rest = deck.slice(index, deck.length - 1);
 
   return {
     players,
@@ -105,6 +103,10 @@ export function defend(state: GameState, attackIndex: number, cardId: string): b
   if (!canBeat(pair.attack, card, state.trump)) return false;
   defender.hand.splice(idx, 1);
   pair.defense = card;
-  if (state.table.every(p => p.defense)) state.phase = 'resolution';
+  if (state.table.every(p => p.defense)) {
+    state.phase = 'resolution';
+  } else {
+    state.phase = 'attack';
+  }
   return true;
 }

--- a/tests/logic.test.ts
+++ b/tests/logic.test.ts
@@ -34,4 +34,26 @@ describe('attack and defend logic', () => {
     expect(bad).toBe(true);
     expect(state.table[0].defense?.id).toBe('7_of_clubs');
   });
+
+  test('cannot add card with wrong rank', () => {
+    const state = setupState();
+    const extra: Card = { id: '8_of_hearts', rank: 8, suit: 'hearts' };
+    state.players.human.hand.push(extra);
+    attack(state, '6_of_clubs');
+    defend(state, 0, '7_of_clubs');
+    const ok = attack(state, '8_of_hearts');
+    expect(ok).toBe(false);
+    expect(state.players.human.hand).toContain(extra);
+  });
+
+  test('defend fails with weaker card', () => {
+    const state = setupState();
+    const weak: Card = { id: '5_of_clubs', rank: 5, suit: 'clubs' };
+    state.players.ai.hand.push(weak);
+    attack(state, '6_of_clubs');
+    const ok = defend(state, 0, '5_of_clubs');
+    expect(ok).toBe(false);
+    expect(state.table[0].defense).toBeUndefined();
+    expect(state.players.ai.hand).toContain(weak);
+  });
 });


### PR DESCRIPTION
## Summary
- fix duplicate deck slice in dealInitial
- improve defend() to toggle phase back to attack when not finished
- add negative tests for wrong rank attack and invalid defense
- compile dist

## Testing
- `npm test`
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_685bfc2da72c8323ac6491466edcfa88