### PR TITLE
Add basic Durak gameplay controls

### DIFF
--- a/GameSite/wwwroot/js/durak-ui.js
+++ b/GameSite/wwwroot/js/durak-ui.js
@@ -1,4 +1,4 @@
-import { dealInitial, attack, defend, aiMove, canBeat } from './durak.js';
+import { dealInitial, attack, defend, aiMove, canBeat, takeCards, finishRound } from './durak.js';
 
 document.addEventListener('DOMContentLoaded', () => {
   const root = document.getElementById('durak-root');
@@ -84,6 +84,30 @@ document.addEventListener('DOMContentLoaded', () => {
     page.appendChild(table);
     page.appendChild(deckArea);
     page.appendChild(playerHand);
+
+    const controls = document.createElement('div');
+    controls.className = 'controls';
+    const takeBtn = document.createElement('button');
+    takeBtn.textContent = '\u0412\u0437\u044F\u0442\u044C';
+    takeBtn.addEventListener('click', () => {
+      if(state && state.defender === 'human' && (state.phase === 'defense' || state.phase === 'resolution')) {
+        takeCards(state);
+        renderGame();
+        setTimeout(aiTurn, 500);
+      }
+    });
+    const bitoBtn = document.createElement('button');
+    bitoBtn.textContent = '\u0411\u0438\u0442\u043E';
+    bitoBtn.addEventListener('click', () => {
+      if(state && state.phase === 'resolution') {
+        finishRound(state);
+        renderGame();
+        setTimeout(aiTurn, 500);
+      }
+    });
+    controls.appendChild(takeBtn);
+    controls.appendChild(bitoBtn);
+    page.appendChild(controls);
     root.appendChild(page);
   }
 

--- a/src/durak.ts
+++ b/src/durak.ts
@@ -126,11 +126,43 @@ export function aiMove(state: GameState): void {
     if(def){
       defend(state, idx, def.id);
     } else {
-      hand.push(...state.table.flatMap(p => [p.attack, ...(p.defense ? [p.defense] : [])]));
-      state.table = [];
-      state.phase = 'attack';
+      takeCards(state);
       state.attacker = 'ai';
       state.defender = 'human';
     }
+  }
+  if(state.phase === 'resolution' && (state.attacker === 'ai' || state.defender === 'ai')){
+    finishRound(state);
+  }
+}
+
+export function takeCards(state: GameState): void {
+  const defender = state.players[state.defender];
+  defender.hand.push(...state.table.flatMap(p => [p.attack, ...(p.defense ? [p.defense] : [])]));
+  state.table = [];
+  refillHands(state);
+  state.phase = 'attack';
+}
+
+export function finishRound(state: GameState): void {
+  state.table = [];
+  const newAttacker = state.defender;
+  state.defender = state.attacker;
+  state.attacker = newAttacker;
+  refillHands(state);
+  state.phase = 'attack';
+}
+
+export function refillHands(state: GameState): void {
+  const order: ('human' | 'ai')[] = [state.attacker, state.defender];
+  for (const role of order) {
+    const player = state.players[role];
+    while (player.hand.length < 6 && state.deck.length > 0) {
+      const c = state.deck.shift();
+      if (c) player.hand.push(c);
+    }
+  }
+  if(state.players.human.hand.length === 0 && state.players.ai.hand.length === 0 && state.deck.length === 0) {
+    state.phase = 'finished';
   }
 }


### PR DESCRIPTION
## Summary
- implement `takeCards`, `finishRound`, `refillHands` logic in Durak engine
- update AI logic to use new functions
- expose controls in Durak UI with "Взять" and "Бито" buttons
- compile TypeScript to JS

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_686226d5c9608323be89fbfa9cf8ec2e