### PR TITLE
Enable card throw-in during defense

### DIFF
--- a/GameSite/wwwroot/js/durak-ui.js
+++ b/GameSite/wwwroot/js/durak-ui.js
@@ -131,7 +131,7 @@ document.addEventListener('DOMContentLoaded', () => {
 
   function onCardClick(card) {
     if (!state) return;
-    if (state.attacker === 'human' && state.phase === 'attack') {
+    if (state.attacker === 'human' && (state.phase === 'attack' || state.phase === 'defense')) {
       if (attack(state, card.id)) {
         renderGame();
         setTimeout(aiTurn, 500);

--- a/GameSite/wwwroot/js/durak.js
+++ b/GameSite/wwwroot/js/durak.js
@@ -70,7 +70,7 @@ export function canBeat(att, def, trump) {
     return false;
 }
 export function attack(state, cardId) {
-    if (state.phase !== 'attack')
+    if (state.phase !== 'attack' && state.phase !== 'defense')
         return false;
     const player = state.players[state.attacker];
     const idx = player.hand.findIndex(c => c.id === cardId);
@@ -116,7 +116,7 @@ export function defend(state, attackIndex, cardId) {
     return true;
 }
 export function aiMove(state) {
-    if (state.attacker === 'ai' && state.phase === 'attack') {
+    if (state.attacker === 'ai' && (state.phase === 'attack' || state.phase === 'defense')) {
         const hand = state.players.ai.hand;
         const ranks = ranksOnTable(state);
         const limit = Math.min(6, state.players[state.defender].hand.length);

--- a/dist/durak.js
+++ b/dist/durak.js
@@ -82,7 +82,7 @@ function canBeat(att, def, trump) {
     return false;
 }
 function attack(state, cardId) {
-    if (state.phase !== 'attack')
+    if (state.phase !== 'attack' && state.phase !== 'defense')
         return false;
     const player = state.players[state.attacker];
     const idx = player.hand.findIndex(c => c.id === cardId);
@@ -128,7 +128,7 @@ function defend(state, attackIndex, cardId) {
     return true;
 }
 function aiMove(state) {
-    if (state.attacker === 'ai' && state.phase === 'attack') {
+    if (state.attacker === 'ai' && (state.phase === 'attack' || state.phase === 'defense')) {
         const hand = state.players.ai.hand;
         const ranks = ranksOnTable(state);
         const limit = Math.min(6, state.players[state.defender].hand.length);

--- a/src/durak.ts
+++ b/src/durak.ts
@@ -85,7 +85,7 @@ export function canBeat(att: Card, def: Card, trump: Suit): boolean {
 }
 
 export function attack(state: GameState, cardId: string): boolean {
-  if (state.phase !== 'attack') return false;
+  if (state.phase !== 'attack' && state.phase !== 'defense') return false;
   const player = state.players[state.attacker];
   const idx = player.hand.findIndex(c => c.id === cardId);
   if (idx === -1) return false;
@@ -125,7 +125,7 @@ export function defend(state: GameState, attackIndex: number, cardId: string): b
 }
 
 export function aiMove(state: GameState): void {
-  if(state.attacker === 'ai' && state.phase === 'attack'){
+  if(state.attacker === 'ai' && (state.phase === 'attack' || state.phase === 'defense')){
     const hand = state.players.ai.hand;
     const ranks = ranksOnTable(state);
     const suits = suitsOnTable(state);

--- a/tests/logic.test.ts
+++ b/tests/logic.test.ts
@@ -68,6 +68,17 @@ describe('attack and defend logic', () => {
     expect(ok).toBe(false);
   });
 
+  test('attacker can add card during defense', () => {
+    const state = setupState();
+    const extra: Card = { id: '6_of_hearts', rank: 6, suit: 'hearts' };
+    state.players.human.hand.push(extra);
+    state.players.ai.hand.push({ id: '8_of_spades', rank: 8, suit: 'spades' });
+    attack(state, '6_of_clubs'); // phase becomes defense
+    const ok = attack(state, '6_of_hearts');
+    expect(ok).toBe(true);
+    expect(state.table).toHaveLength(2);
+  });
+
   test('attacker can add card with matching suit', () => {
     const state = setupState();
     const extra: Card = { id: '9_of_clubs', rank: 9, suit: 'clubs' };
@@ -106,5 +117,27 @@ describe('attack and defend logic', () => {
     aiMove(state);
     expect(state.table).toHaveLength(2);
     expect(state.table[1].attack.suit).toBe('spades');
+  });
+
+  test('ai can add card during defense', () => {
+    const c1: Card = { id: '6_of_spades', rank: 6, suit: 'spades' };
+    const c2: Card = { id: '6_of_hearts', rank: 6, suit: 'hearts' };
+    const defendCard: Card = { id: '7_of_clubs', rank: 7, suit: 'clubs' };
+    const spare: Card = { id: '8_of_diamonds', rank: 8, suit: 'diamonds' };
+    const state: GameState = {
+      players: {
+        human: { hand: [defendCard, spare], role: 'human' },
+        ai: { hand: [c1, c2], role: 'ai' }
+      },
+      deck: [],
+      trump: 'diamonds',
+      attacker: 'ai',
+      defender: 'human',
+      table: [],
+      phase: 'attack'
+    };
+    aiMove(state); // AI plays first card
+    aiMove(state); // should add second card even though phase is defense
+    expect(state.table).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary
- allow additional attack cards while defense is in progress
- let AI add cards in defense phase
- update UI click handling
- update compiled JS
- cover defense throw-in with new tests

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68625a1f042c832399786b736695310e