### PR TITLE
Fix card throw-in state after defense

### DIFF
--- a/GameSite/wwwroot/js/durak.js
+++ b/GameSite/wwwroot/js/durak.js
@@ -107,8 +107,8 @@ export function defend(state, attackIndex, cardId) {
     defender.hand.splice(idx, 1);
     pair.defense = card;
     state.lastMove = { player: state.defender, action: 'defense', card };
-    if (state.table.every(p => p.defense)) {
-        state.phase = 'resolution';
+    if (state.table.some(p => !p.defense)) {
+        state.phase = 'defense';
     }
     else {
         state.phase = 'attack';

--- a/dist/durak.js
+++ b/dist/durak.js
@@ -119,8 +119,8 @@ function defend(state, attackIndex, cardId) {
     defender.hand.splice(idx, 1);
     pair.defense = card;
     state.lastMove = { player: state.defender, action: 'defense', card };
-    if (state.table.every(p => p.defense)) {
-        state.phase = 'resolution';
+    if (state.table.some(p => !p.defense)) {
+        state.phase = 'defense';
     }
     else {
         state.phase = 'attack';


### PR DESCRIPTION
## Summary
- prevent automatic resolution when a card is defended
- keep the round in `defense` phase while there are unblocked attacks

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68625d6080588323b89ea752705fdbb5